### PR TITLE
절대 경로 자동 완성 src 기준으로 되는 문제 해결

### DIFF
--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
-      "@/*": ["src/*"],
       "@pages/*": ["src/pages/*"],
       "@features/*": ["src/features/*"],
       "@components/*": ["src/components/*"],


### PR DESCRIPTION
## 연관 이슈

- #40

## 작업 요약

- src 기준이 아닌 지정한 절대 경로로 자동 완성되도록 수정해주었습니다.

### Before
<img width="405" alt="Image" src="https://github.com/user-attachments/assets/8a48d2de-f97c-4c30-a4c4-58f7a4fcf8e1" />

### After
<img width="391" alt="Image" src="https://github.com/user-attachments/assets/4bb92204-7a14-4741-bb45-4d0ee4bbd375" />

## 리뷰 요구사항

- 예상 소요 시간 1분