### PR TITLE
팔로워 팔로잉 다이얼로그 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -42,7 +42,7 @@ const App: React.FC = () => {
               <Route path="/login-signup" element={<LoginSignup />} />
               <Route path="/feed" element={<FeedPage />} />
               <Route path="/search" element={<BookSearchPage />} />
-              <Route path="/my-page" element={<MyPage />} />
+              <Route path="/my-page/:userId?" element={<MyPage />} />
               <Route path="/" element={<FeedPage />} />
             </Routes>
           </main>

--- a/src/components/MyPage/FollowList.tsx
+++ b/src/components/MyPage/FollowList.tsx
@@ -7,12 +7,14 @@ import {
   IconButton,
 } from '@mui/material';
 import DeleteIcon from '@mui/icons-material/Delete';
+import { useNavigate } from 'react-router-dom';
 
 const FollowList = () => {
   /* TODO API 연동 필요 */
   const users = [
     {
       id: 1,
+      userId: 'kim',
       name: '김독서',
       avartarUrl: '',
       about: '책을 사랑하는 독서가',
@@ -24,7 +26,8 @@ const FollowList = () => {
     },
     {
       id: 2,
-      name: '김독서',
+      userId: 'lee',
+      name: '이독서',
       avartarUrl: '',
       about: '책을 사랑하는 독서가',
       userStats: [
@@ -35,7 +38,8 @@ const FollowList = () => {
     },
     {
       id: 3,
-      name: '김독서',
+      userId: 'jung',
+      name: '정독서',
       avartarUrl: '',
       about: '책을 사랑하는 독서가',
       userStats: [
@@ -46,13 +50,19 @@ const FollowList = () => {
     },
   ];
 
+  const navigate = useNavigate();
+
+  const handleUserClick = (userId: string) => {
+    navigate(userId);
+  };
+
   const handleDeleteIconClick = () => {
     /* TODO 삭제 API 연동 필요 */
   };
 
   return (
     <List sx={{ gap: 2 }}>
-      {users.map(({ id, name, avartarUrl }) => (
+      {users.map(({ id, userId, name, avartarUrl }) => (
         <ListItem
           key={id}
           secondaryAction={
@@ -65,10 +75,17 @@ const FollowList = () => {
             </IconButton>
           }
         >
-          <ListItemAvatar>
+          <ListItemAvatar
+            onClick={() => handleUserClick(userId)}
+            sx={{ cursor: 'pointer' }}
+          >
             <Avatar src={avartarUrl} />
           </ListItemAvatar>
-          <ListItemText primary={name} />
+          <ListItemText
+            primary={name}
+            onClick={() => handleUserClick(userId)}
+            sx={{ cursor: 'pointer' }}
+          />
         </ListItem>
       ))}
     </List>

--- a/src/components/MyPage/FollowList.tsx
+++ b/src/components/MyPage/FollowList.tsx
@@ -46,13 +46,21 @@ const FollowList = () => {
     },
   ];
 
+  const handleDeleteIconClick = () => {
+    /* TODO 삭제 API 연동 필요 */
+  };
+
   return (
     <List sx={{ gap: 2 }}>
       {users.map(({ id, name, avartarUrl }) => (
         <ListItem
           key={id}
           secondaryAction={
-            <IconButton edge="end" aria-label="delete">
+            <IconButton
+              edge="end"
+              aria-label="delete"
+              onClick={handleDeleteIconClick}
+            >
               <DeleteIcon />
             </IconButton>
           }

--- a/src/components/MyPage/FollowList.tsx
+++ b/src/components/MyPage/FollowList.tsx
@@ -1,0 +1,70 @@
+import {
+  List,
+  ListItem,
+  ListItemAvatar,
+  Avatar,
+  ListItemText,
+  IconButton,
+} from '@mui/material';
+import DeleteIcon from '@mui/icons-material/Delete';
+
+const FollowList = () => {
+  /* TODO API 연동 필요 */
+  const users = [
+    {
+      id: 1,
+      name: '김독서',
+      avartarUrl: '',
+      about: '책을 사랑하는 독서가',
+      userStats: [
+        { count: 286, label: '피드' },
+        { count: 842, label: '팔로워', isAction: true },
+        { count: 267, label: '팔로잉', isAction: true },
+      ],
+    },
+    {
+      id: 2,
+      name: '김독서',
+      avartarUrl: '',
+      about: '책을 사랑하는 독서가',
+      userStats: [
+        { count: 286, label: '피드' },
+        { count: 842, label: '팔로워', isAction: true },
+        { count: 267, label: '팔로잉', isAction: true },
+      ],
+    },
+    {
+      id: 3,
+      name: '김독서',
+      avartarUrl: '',
+      about: '책을 사랑하는 독서가',
+      userStats: [
+        { count: 286, label: '피드' },
+        { count: 842, label: '팔로워', isAction: true },
+        { count: 267, label: '팔로잉', isAction: true },
+      ],
+    },
+  ];
+
+  return (
+    <List sx={{ gap: 2 }}>
+      {users.map(({ id, name, avartarUrl }) => (
+        <ListItem
+          key={id}
+          secondaryAction={
+            <IconButton edge="end" aria-label="delete">
+              <DeleteIcon />
+            </IconButton>
+          }
+        >
+          <ListItemAvatar>
+            <Avatar src={avartarUrl} />
+          </ListItemAvatar>
+          <ListItemText primary={name} />
+        </ListItem>
+      ))}
+    </List>
+  );
+};
+
+export default FollowList;

--- a/src/components/MyPage/TabSection.tsx
+++ b/src/components/MyPage/TabSection.tsx
@@ -1,11 +1,16 @@
 import { Stack, Tab, Tabs } from '@mui/material';
 import { useState } from 'react';
 
-const TabSection = (): JSX.Element => {
+interface TabSectionProps {
+  userId: string;
+}
+
+const TabSection = ({ userId }: TabSectionProps): JSX.Element => {
+  /* TODO 탭 콘텐츠 제작 완료 후 userId 넘겨주기  */
   const tabs = [
-    { id: 1, label: '내 서재', component: <></> },
-    { id: 2, label: '내 피드', component: <></> },
-    { id: 2, label: '북마크', component: <></> },
+    { id: 1, label: '내 서재', component: <>{userId}</> },
+    { id: 2, label: '내 피드', component: <>{userId}</> },
+    { id: 2, label: '북마크', component: <>{userId}</> },
   ];
 
   const [tab, setTab] = useState(0);

--- a/src/components/MyPage/UserInfoSection.tsx
+++ b/src/components/MyPage/UserInfoSection.tsx
@@ -9,8 +9,8 @@ const UserInfoSection = (): JSX.Element => {
     about: '책을 사랑하는 독서가',
     userStats: [
       { count: 286, label: '피드' },
-      { count: 842, label: '팔로워' },
-      { count: 267, label: '팔로잉' },
+      { count: 842, label: '팔로워', isAction: true },
+      { count: 267, label: '팔로잉', isAction: true },
     ],
   };
 
@@ -21,13 +21,18 @@ const UserInfoSection = (): JSX.Element => {
         src={user.avartarUrl}
         sx={{ width: 100, height: 100 }}
       />
-      <Stack spacing={2}>
+      <Stack spacing={1}>
         <Typography variant="h6" fontWeight="bold">
           {user.name}
         </Typography>
-        <Stack direction="row" spacing={4}>
-          {user?.userStats?.map(({ count, label }) => (
-            <UserInfoSummary key={label} count={count} label={label} />
+        <Stack direction="row" spacing={2} alignItems="center">
+          {user?.userStats?.map(({ count, label, isAction }) => (
+            <UserInfoSummary
+              key={label}
+              count={count}
+              label={label}
+              isAction={isAction}
+            />
           ))}
         </Stack>
         <Typography variant="body2" color="grey.700">

--- a/src/components/MyPage/UserInfoSection.tsx
+++ b/src/components/MyPage/UserInfoSection.tsx
@@ -1,10 +1,15 @@
 import { Avatar, Stack, Typography } from '@mui/material';
 import UserInfoSummary from './UserInfoSummary';
 
-const UserInfoSection = (): JSX.Element => {
+interface UserInfoSectionProps {
+  userId: string;
+}
+
+const UserInfoSection = ({ userId }: UserInfoSectionProps): JSX.Element => {
   /* TODO user api로 받아오기  */
-  const user = {
+  const user = (userId: string) => ({
     name: '김독서',
+    userId: userId, // 실제로는 응답에 따른 값이 들어갑니다.
     avartarUrl: '',
     about: '책을 사랑하는 독서가',
     userStats: [
@@ -12,21 +17,21 @@ const UserInfoSection = (): JSX.Element => {
       { count: 842, label: '팔로워', isAction: true },
       { count: 267, label: '팔로잉', isAction: true },
     ],
-  };
+  });
 
   return (
     <Stack direction="row" alignItems="center" spacing={4} padding={4}>
       <Avatar
-        alt={user.name}
-        src={user.avartarUrl}
+        alt={user(userId).name}
+        src={user(userId).avartarUrl}
         sx={{ width: 100, height: 100 }}
       />
       <Stack spacing={1}>
         <Typography variant="h6" fontWeight="bold">
-          {user.name}
+          {user(userId).name}
         </Typography>
         <Stack direction="row" spacing={2} alignItems="center">
-          {user?.userStats?.map(({ count, label, isAction }) => (
+          {user(userId)?.userStats?.map(({ count, label, isAction }) => (
             <UserInfoSummary
               key={label}
               count={count}
@@ -36,7 +41,7 @@ const UserInfoSection = (): JSX.Element => {
           ))}
         </Stack>
         <Typography variant="body2" color="grey.700">
-          {user.about}
+          {user(userId).about}
         </Typography>
       </Stack>
     </Stack>

--- a/src/components/MyPage/UserInfoSection.tsx
+++ b/src/components/MyPage/UserInfoSection.tsx
@@ -7,7 +7,6 @@ interface UserInfoSectionProps {
 
 const UserInfoSection = ({ userId }: UserInfoSectionProps): JSX.Element => {
   /* TODO user api로 받아오기  */
-  /* 본인이 아닐 경우 isAction은 모두 false -> api 연동 후 처리 */
   const user = (userId: string) => ({
     name: '김독서',
     userId: userId, // 실제로는 응답에 따른 값이 들어갑니다.

--- a/src/components/MyPage/UserInfoSection.tsx
+++ b/src/components/MyPage/UserInfoSection.tsx
@@ -7,6 +7,7 @@ interface UserInfoSectionProps {
 
 const UserInfoSection = ({ userId }: UserInfoSectionProps): JSX.Element => {
   /* TODO user api로 받아오기  */
+  /* 본인이 아닐 경우 isAction은 모두 false -> api 연동 후 처리 */
   const user = (userId: string) => ({
     name: '김독서',
     userId: userId, // 실제로는 응답에 따른 값이 들어갑니다.

--- a/src/components/MyPage/UserInfoSummary.tsx
+++ b/src/components/MyPage/UserInfoSummary.tsx
@@ -1,6 +1,7 @@
 import { Button, Stack, Typography } from '@mui/material';
 import HybridDialog from '../commons/HybridDialog';
 import { useState } from 'react';
+import FollowList from './FollowList';
 
 interface UserInfoSummaryProps {
   count: number;
@@ -31,7 +32,7 @@ const UserInfoSummary = ({ count, label, isAction }: UserInfoSummaryProps) => {
         open={open}
         setOpen={setOpen}
         title={label}
-        contentNode={<></>}
+        contentNode={<FollowList />}
       />
     </Stack>
   );

--- a/src/components/MyPage/UserInfoSummary.tsx
+++ b/src/components/MyPage/UserInfoSummary.tsx
@@ -1,4 +1,6 @@
 import { Button, Stack, Typography } from '@mui/material';
+import HybridDialog from '../commons/HybridDialog';
+import { useState } from 'react';
 
 interface UserInfoSummaryProps {
   count: number;
@@ -7,15 +9,30 @@ interface UserInfoSummaryProps {
 }
 
 const UserInfoSummary = ({ count, label, isAction }: UserInfoSummaryProps) => {
+  const [open, setOpen] = useState(false);
+
   return (
     <Stack
       component={isAction ? Button : 'div'}
       alignItems="center"
       padding="6px 4px"
       minWidth={64}
+      onClick={
+        isAction
+          ? () => {
+              setOpen(true);
+            }
+          : undefined
+      }
     >
       <Typography>{count}</Typography>
       <Typography>{label}</Typography>
+      <HybridDialog
+        open={open}
+        setOpen={setOpen}
+        title={label}
+        contentNode={<></>}
+      />
     </Stack>
   );
 };

--- a/src/components/MyPage/UserInfoSummary.tsx
+++ b/src/components/MyPage/UserInfoSummary.tsx
@@ -13,28 +13,30 @@ const UserInfoSummary = ({ count, label, isAction }: UserInfoSummaryProps) => {
   const [open, setOpen] = useState(false);
 
   return (
-    <Stack
-      component={isAction ? Button : 'div'}
-      alignItems="center"
-      padding="6px 4px"
-      minWidth={64}
-      onClick={
-        isAction
-          ? () => {
-              setOpen(true);
-            }
-          : undefined
-      }
-    >
-      <Typography>{count}</Typography>
-      <Typography>{label}</Typography>
+    <>
+      <Stack
+        component={isAction ? Button : 'div'}
+        alignItems="center"
+        padding="6px 4px"
+        minWidth={64}
+        onClick={
+          isAction
+            ? () => {
+                setOpen(true);
+              }
+            : undefined
+        }
+      >
+        <Typography>{count}</Typography>
+        <Typography>{label}</Typography>
+      </Stack>
       <HybridDialog
         open={open}
         setOpen={setOpen}
         title={label}
         contentNode={<FollowList />}
       />
-    </Stack>
+    </>
   );
 };
 

--- a/src/components/MyPage/UserInfoSummary.tsx
+++ b/src/components/MyPage/UserInfoSummary.tsx
@@ -1,13 +1,19 @@
-import { Stack, Typography } from '@mui/material';
+import { Button, Stack, Typography } from '@mui/material';
 
 interface UserInfoSummaryProps {
   count: number;
   label: string;
+  isAction?: boolean;
 }
 
-const UserInfoSummary = ({ count, label }: UserInfoSummaryProps) => {
+const UserInfoSummary = ({ count, label, isAction }: UserInfoSummaryProps) => {
   return (
-    <Stack alignItems="center">
+    <Stack
+      component={isAction ? Button : 'div'}
+      alignItems="center"
+      padding="6px 4px"
+      minWidth={64}
+    >
       <Typography>{count}</Typography>
       <Typography>{label}</Typography>
     </Stack>

--- a/src/pages/MyPage/MyPage.tsx
+++ b/src/pages/MyPage/MyPage.tsx
@@ -1,12 +1,16 @@
 import TabSection from '@components/MyPage/TabSection';
 import UserInfoSection from '@components/MyPage/UserInfoSection';
 import { Container } from '@mui/material';
+import { useParams } from 'react-router-dom';
 
 const MyPage = (): JSX.Element => {
+  /* TODO 로그인 작업 완료 후 내 유저 ID가 기본값으로 들어가도록 확장 */
+  const { userId = '' } = useParams();
+
   return (
     <Container maxWidth="md">
-      <UserInfoSection />
-      <TabSection />
+      <UserInfoSection userId={userId} />
+      <TabSection userId={userId} />
     </Container>
   );
 };


### PR DESCRIPTION
## 연관 이슈

- #37

## 작업 요약

- 팔로워 팔로잉 기능 구현하였습니다.

## 작업 상세 설명

- 팔로워, 팔로잉 버튼 클릭 시 다이얼로그에 해당 리스트들 뜨도록 처리하였습니다.
- 각 리스트에서도 아바타와 이름의 경우 클릭 이벤트를 넣어주어, 클릭 시 해당 사용자의 페이지로 이동할 수 있도록 처리하였습니다.
  - userId에 따른 페이지 라우팅 되도록 처리하였습니다.
  - 이동된 페이지에 대한 유저 정보 처리는 API 연동 후 정상적으로 반영될 예정입니다. (현재는 이동만 하고, 동일한 목데이터를 사용합니다.)
- 삭제 버튼 클릭 시에 대한 처리는 핸들러만 먼저 생성해둔 상태이고, 이후 API 만들어지면 연동이 필요합니다.

## 리뷰 요구사항

- 리뷰 예상 시간 10분

## Preview 이미지 (필요시)

<img width="500" alt="image" src="https://github.com/user-attachments/assets/679339da-6825-4b5f-8abc-f8107157e7bd" />

<img width="500" alt="image" src="https://github.com/user-attachments/assets/b04ca4e5-f93c-47a7-9cd9-c497f4171133" />
