### PR TITLE
다이얼로그 외부 클릭 시 안 닫히는 문제 해결

### DIFF
--- a/src/components/commons/HybridDialog.tsx
+++ b/src/components/commons/HybridDialog.tsx
@@ -56,6 +56,7 @@ const HybridDialog = ({
       fullWidth={true}
       maxWidth={maxWidth}
       open={open}
+      onClose={handleClose}
       closeAfterTransition={false}
     >
       <DialogTitle>

--- a/src/components/commons/HybridDialog.tsx
+++ b/src/components/commons/HybridDialog.tsx
@@ -39,17 +39,15 @@ const HybridDialog = ({
   open,
   setOpen,
 }: HybridDialogProps): JSX.Element => {
-  const handleClose = (e: React.MouseEvent<HTMLButtonElement>) => {
-    e.stopPropagation();
+  const handleClose = () => {
     setOpen(false);
   };
 
-  const handleAction = (e: React.MouseEvent<HTMLButtonElement>) => {
+  const handleAction = () => {
     if (!onActionClick) return;
-    e.stopPropagation();
 
     onActionClick();
-    handleClose(e);
+    handleClose();
   };
 
   return (


### PR DESCRIPTION
## 연관 이슈

- #52 

## 작업 요약

- `onClose={handleClose}` 추가하여 다이얼로그 외부 클릭 시에도 닫히도록 처리하였습니다.

## 작업 상세 설명

- e.stopPropagation(); 이전에 이벤트 전파 문제가 발생하는 것 같아서 해당 코드 작성해두었는데, 다이얼로그 활용하는 부분에서 문제가 있었던 것이여서, 불필요한 코드라 지금은 삭제해주었습니다.
  <details>
  <summary>참고 - 이벤트 전파 문제 발생하는 경우</summary>
  <div markdown="1">
  
  https://github.com/user-attachments/assets/f819d2d4-e4cc-4b82-82af-988ab7a1c008

  ```tsx
   <Button
      onClick={() => {
        setOpen(true);
      }}
    >
      <Typography>{count}</Typography>
      <Typography>{label}</Typography>
      <HybridDialog
        open={open}
        setOpen={setOpen}
        title={label}
        contentNode={<FollowList />}
      />
    </Button>
  ```

  react portal을 사용하여 DOM 위치 상으로는 React 트리와 분리되어 위치하지만, 이벤트 전파는 React 트리를 따라서 동작하기 때문에, 클리 요소 하위에 다이얼로그를 배치하게 되면, 이벤트 전파가 일어나면서 다이얼로그 클릭 시 버튼 클릭 이벤트가 발생하게 됩니다.

  ```tsx
    <>
      <Button
        onClick={() => {
          setOpen(true);
        }}
      >
        <Typography>{count}</Typography>
        <Typography>{label}</Typography>
      </Button>
      <HybridDialog
        open={open}
        setOpen={setOpen}
        title={label}
        contentNode={<FollowList />}
      />
    </>
  ```
  이벤트 전파가 발생하지 않도록 하기 위해서는 위의 코드와 같이 다이얼로그가 클릭 요소 하위에 위치하지 않도록 코드가 작성되어야 합니다.
  </div>
  </details>

## 리뷰 요구사항

- 5분 소요 예상
