### PR TITLE
포스트 작성 기능 구현

### DIFF
--- a/src/components/FeedPage/OneLineReviewDialog.tsx
+++ b/src/components/FeedPage/OneLineReviewDialog.tsx
@@ -1,21 +1,9 @@
-import {
-  Box,
-  Button,
-  Dialog,
-  DialogActions,
-  DialogContent,
-  DialogTitle,
-  IconButton,
-  Stack,
-  TextField,
-  Typography,
-} from '@mui/material';
-import ArrowBackIcon from '@mui/icons-material/ArrowBack';
-import CloseIcon from '@mui/icons-material/Close';
+import { Box, Stack, TextField, Typography } from '@mui/material';
 import React, { useEffect, useState } from 'react';
 import { PostType } from './WriteDialog';
 import BookSearchAutoComplete from '@components/commons/BookSearchAutoComplete';
 import { Book } from '@shared/types/type';
+import HybridDialog from '@components/commons/HybridDialog';
 
 interface OneLineReviewDialogProps {
   handleBack: () => void;
@@ -30,114 +18,85 @@ const OneLineReviewDialog = ({
 }: OneLineReviewDialogProps) => {
   const [searchQuery, setSearchQuery] = useState('');
   const [selectedBook, setSelectedBook] = useState<Book | null>(null);
+  const [review, setReview] = useState('');
+
   // 다이얼로그 닫히면 책 검색 결과 초기화
   useEffect(() => {
     if (selectedType !== 'review') {
       setSelectedBook(null);
       setSearchQuery('');
+      setReview('');
     }
   }, [selectedType]);
 
+  const handleSubmit = () => {
+    // 한줄평 제출 로직 구현
+    console.log('한줄평 제출:', { selectedBook, review });
+  };
+
+  const contentNode = (
+    <Stack sx={{ gap: '20px' }}>
+      <BookSearchAutoComplete
+        searchQuery={searchQuery}
+        setSearchQuery={setSearchQuery}
+        selectedBook={selectedBook}
+        setSelectedBook={setSelectedBook}
+      />
+
+      {selectedBook && (
+        <Box>
+          <Stack direction="row" spacing={2} alignItems="center">
+            <img
+              src={selectedBook.imageUrl}
+              alt={selectedBook.bookTitle}
+              style={{ width: 60, height: 90 }}
+            />
+            <Stack>
+              <Typography>{selectedBook.bookTitle}</Typography>
+              <Typography variant="body2">{selectedBook.author}</Typography>
+              <Typography>{selectedBook.itemId}</Typography>
+            </Stack>
+          </Stack>
+        </Box>
+      )}
+
+      <TextField
+        fullWidth
+        multiline
+        label="한줄평"
+        variant="outlined"
+        placeholder="한줄평을 입력하세요"
+        value={review}
+        onChange={(e) => setReview(e.target.value)}
+        minRows={12}
+        sx={{
+          '& .MuiOutlinedInput-root': {
+            borderRadius: '8px',
+            height: '200px',
+            '& textarea': {
+              height: '100% !important',
+            },
+          },
+        }}
+      />
+    </Stack>
+  );
+
   return (
-    <Dialog
-      fullWidth
-      maxWidth="xs"
+    <HybridDialog
       open={selectedType === 'review'}
-      onClose={() => setSelectedType(null)}
+      setOpen={() => setSelectedType(null)}
+      title="한줄평 작성"
+      onBack={handleBack}
+      action="한줄평 작성"
+      onActionClick={handleSubmit}
+      contentNode={contentNode}
       sx={{
         '& .MuiDialog-paper': {
           borderRadius: '10px',
         },
       }}
-    >
-      <DialogTitle>
-        <Stack
-          direction="row"
-          justifyContent="space-between"
-          alignItems="center"
-        >
-          <Stack direction="row" alignItems="center" spacing={1}>
-            <IconButton onClick={handleBack}>
-              <ArrowBackIcon />
-            </IconButton>
-            <Typography>한줄평 작성</Typography>
-          </Stack>
-          <IconButton onClick={() => setSelectedType(null)}>
-            <CloseIcon />
-          </IconButton>
-        </Stack>
-      </DialogTitle>
-      <DialogContent
-        sx={{
-          display: 'flex',
-          flexDirection: 'column',
-          gap: '30px',
-          '&.MuiDialogContent-root': {
-            padding: '30px 20px',
-          },
-        }}
-      >
-        <BookSearchAutoComplete
-          searchQuery={searchQuery}
-          setSearchQuery={setSearchQuery}
-          selectedBook={selectedBook}
-          setSelectedBook={setSelectedBook}
-        />
-
-        {selectedBook && (
-          <Box sx={{ mb: 2 }}>
-            <Stack direction="row" spacing={2} alignItems="center">
-              <img
-                src={selectedBook.imageUrl}
-                alt={selectedBook.bookTitle}
-                style={{ width: 60, height: 90 }}
-              />
-              <Stack>
-                <Typography>{selectedBook.bookTitle}</Typography>
-                <Typography variant="body2">{selectedBook.author}</Typography>
-                <Typography>{selectedBook.itemId}</Typography>
-              </Stack>
-            </Stack>
-          </Box>
-        )}
-
-        <TextField
-          fullWidth
-          multiline
-          label="한줄평"
-          variant="outlined"
-          placeholder="한줄평을 입력하세요"
-          minRows={12}
-          sx={{
-            '& .MuiOutlinedInput-root': {
-              borderRadius: '8px',
-              height: '200px',
-              '& textarea': {
-                height: '100% !important',
-              },
-            },
-          }}
-        />
-      </DialogContent>
-      <DialogActions
-        sx={{
-          justifyContent: 'center',
-          padding: '0',
-        }}
-      >
-        <Button
-          variant="contained"
-          sx={{
-            margin: '0',
-            width: '100%',
-            padding: '10px',
-            borderRadius: '0px 0px 10px 10px',
-          }}
-        >
-          한줄평 작성
-        </Button>{' '}
-      </DialogActions>
-    </Dialog>
+    />
   );
 };
 

--- a/src/components/FeedPage/OneLineReviewDialog.tsx
+++ b/src/components/FeedPage/OneLineReviewDialog.tsx
@@ -1,5 +1,4 @@
 import {
-  Autocomplete,
   Box,
   Button,
   Dialog,
@@ -15,7 +14,8 @@ import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import CloseIcon from '@mui/icons-material/Close';
 import React, { useEffect, useState } from 'react';
 import { PostType } from './WriteDialog';
-import { useSearchBooksQuery } from '@features/BookSearchPage/api/bookSearchApi';
+import BookSearchAutoComplete from '@components/commons/BookSearchAutoComplete';
+import { Book } from '@shared/types/type';
 
 interface OneLineReviewDialogProps {
   handleBack: () => void;
@@ -29,23 +29,7 @@ const OneLineReviewDialog = ({
   handleBack,
 }: OneLineReviewDialogProps) => {
   const [searchQuery, setSearchQuery] = useState('');
-  const [selectedBook, setSelectedBook] = useState<null | {
-    title: string;
-    itemId: number;
-    author: string;
-    cover: string;
-  }>(null);
-
-  const { data: searchResults } = useSearchBooksQuery(
-    {
-      query: searchQuery,
-      page: 1,
-      sort: 'Accuracy',
-    },
-    {
-      skip: !searchQuery,
-    },
-  );
+  const [selectedBook, setSelectedBook] = useState<Book | null>(null);
   // 다이얼로그 닫히면 책 검색 결과 초기화
   useEffect(() => {
     if (selectedType !== 'review') {
@@ -93,55 +77,23 @@ const OneLineReviewDialog = ({
           },
         }}
       >
-        <Autocomplete
-          fullWidth
-          options={searchResults?.item || []}
-          getOptionLabel={(option) => option.title}
-          onChange={(_, newValue) => {
-            setSelectedBook(newValue);
-          }}
-          renderOption={(props, option) => (
-            <Box component="li" {...props}>
-              <Stack direction="row" spacing={2} alignItems="center">
-                <img
-                  src={option.cover}
-                  alt={option.title}
-                  style={{ width: 40, height: 60 }}
-                />
-                <Stack>
-                  <Typography variant="body1">{option.title}</Typography>
-                  <Typography variant="body2" color="text.secondary">
-                    {option.author}
-                  </Typography>
-                </Stack>
-              </Stack>
-            </Box>
-          )}
-          renderInput={(params) => (
-            <TextField
-              {...params}
-              label="책 검색"
-              onChange={(e) => setSearchQuery(e.target.value)}
-              placeholder="책 제목을 입력하세요"
-              sx={{
-                '& .MuiOutlinedInput-root': {
-                  borderRadius: '8px',
-                },
-              }}
-            />
-          )}
+        <BookSearchAutoComplete
+          searchQuery={searchQuery}
+          setSearchQuery={setSearchQuery}
+          selectedBook={selectedBook}
+          setSelectedBook={setSelectedBook}
         />
 
         {selectedBook && (
           <Box sx={{ mb: 2 }}>
             <Stack direction="row" spacing={2} alignItems="center">
               <img
-                src={selectedBook.cover}
-                alt={selectedBook.title}
+                src={selectedBook.imageUrl}
+                alt={selectedBook.bookTitle}
                 style={{ width: 60, height: 90 }}
               />
               <Stack>
-                <Typography>{selectedBook.title}</Typography>
+                <Typography>{selectedBook.bookTitle}</Typography>
                 <Typography variant="body2">{selectedBook.author}</Typography>
                 <Typography>{selectedBook.itemId}</Typography>
               </Stack>

--- a/src/components/FeedPage/OneLineReviewDialog.tsx
+++ b/src/components/FeedPage/OneLineReviewDialog.tsx
@@ -1,0 +1,118 @@
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  IconButton,
+  Stack,
+  TextField,
+  Typography,
+} from '@mui/material';
+import ArrowBackIcon from '@mui/icons-material/ArrowBack';
+import CloseIcon from '@mui/icons-material/Close';
+import React from 'react';
+import { PostType } from './WriteDialog';
+
+interface OneLineReviewDialogProps {
+  handleBack: () => void;
+  selectedType: PostType;
+  setSelectedType: React.Dispatch<React.SetStateAction<PostType>>;
+}
+
+const OneLineReviewDialog = ({
+  selectedType,
+  setSelectedType,
+  handleBack,
+}: OneLineReviewDialogProps) => {
+  return (
+    <Dialog
+      fullWidth
+      maxWidth="xs"
+      open={selectedType === 'review'}
+      onClose={() => setSelectedType(null)}
+      sx={{
+        '& .MuiDialog-paper': {
+          borderRadius: '10px',
+        },
+      }}
+    >
+      <DialogTitle>
+        <Stack
+          direction="row"
+          justifyContent="space-between"
+          alignItems="center"
+        >
+          <Stack direction="row" alignItems="center" spacing={1}>
+            <IconButton onClick={handleBack}>
+              <ArrowBackIcon />
+            </IconButton>
+            <Typography>한줄평 작성</Typography>
+          </Stack>
+          <IconButton onClick={() => setSelectedType(null)}>
+            <CloseIcon />
+          </IconButton>
+        </Stack>
+      </DialogTitle>
+      <DialogContent
+        sx={{
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '30px',
+          '&.MuiDialogContent-root': {
+            padding: '30px 20px',
+          },
+        }}
+      >
+        <TextField
+          fullWidth
+          label="책 검색"
+          variant="outlined"
+          placeholder="책 제목을 입력하세요"
+          sx={{
+            '& .MuiOutlinedInput-root': {
+              borderRadius: '8px',
+            },
+          }}
+        />
+        <TextField
+          fullWidth
+          multiline
+          label="한줄평"
+          variant="outlined"
+          placeholder="한줄평을 입력하세요"
+          minRows={12} // 약 300px 높이를 위한 설정
+          sx={{
+            '& .MuiOutlinedInput-root': {
+              borderRadius: '8px',
+              height: '300px',
+              '& textarea': {
+                height: '100% !important',
+              },
+            },
+          }}
+        />
+      </DialogContent>
+      <DialogActions
+        sx={{
+          justifyContent: 'center',
+          padding: '0',
+        }}
+      >
+        <Button
+          variant="contained"
+          sx={{
+            margin: '0',
+            width: '100%',
+            padding: '10px',
+            borderRadius: '0px 0px 10px 10px',
+          }}
+        >
+          한줄평 작성
+        </Button>{' '}
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default OneLineReviewDialog;

--- a/src/components/FeedPage/PostingDialog.tsx
+++ b/src/components/FeedPage/PostingDialog.tsx
@@ -1,0 +1,53 @@
+import {
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  IconButton,
+  Stack,
+  Typography,
+} from '@mui/material';
+import ArrowBackIcon from '@mui/icons-material/ArrowBack';
+import CloseIcon from '@mui/icons-material/Close';
+import React from 'react';
+import { PostType } from './WriteDialog';
+
+interface PostingDialogProps {
+  handleBack: () => void;
+  selectedType: PostType;
+  setSelectedType: React.Dispatch<React.SetStateAction<PostType>>;
+}
+
+const PostingDialog = ({
+  selectedType,
+  setSelectedType,
+  handleBack,
+}: PostingDialogProps) => {
+  return (
+    <Dialog
+      fullScreen
+      open={selectedType === 'post'}
+      onClose={() => setSelectedType(null)}
+    >
+      <DialogTitle>
+        <Stack
+          direction="row"
+          justifyContent="space-between"
+          alignItems="center"
+        >
+          <Stack direction="row" alignItems="center" spacing={1}>
+            <IconButton onClick={handleBack}>
+              <ArrowBackIcon />
+            </IconButton>
+            <Typography>포스트 작성</Typography>
+          </Stack>
+          <IconButton onClick={() => setSelectedType(null)}>
+            <CloseIcon />
+          </IconButton>
+        </Stack>
+      </DialogTitle>
+      <DialogContent>{/* 포스트 작성 폼 컴포넌트 */}</DialogContent>
+    </Dialog>
+  );
+};
+
+export default PostingDialog;

--- a/src/components/FeedPage/PostingDialog.tsx
+++ b/src/components/FeedPage/PostingDialog.tsx
@@ -1,15 +1,21 @@
 import {
+  Box,
+  Button,
   Dialog,
+  DialogActions,
   DialogContent,
   DialogTitle,
   IconButton,
   Stack,
+  TextField,
   Typography,
 } from '@mui/material';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import CloseIcon from '@mui/icons-material/Close';
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { PostType } from './WriteDialog';
+import TextEditor from '@components/commons/TextEditor';
+import BookSearchAutoComplete from '@components/commons/BookSearchAutoComplete';
 
 interface PostingDialogProps {
   handleBack: () => void;
@@ -22,6 +28,23 @@ const PostingDialog = ({
   setSelectedType,
   handleBack,
 }: PostingDialogProps) => {
+  const [searchQuery, setSearchQuery] = useState('');
+  const [selectedBook, setSelectedBook] = useState<null | {
+    title: string;
+    itemId: number;
+    author: string;
+    cover: string;
+  }>(null);
+  const [title, setTitle] = useState<string>('');
+  const [content, setContent] = useState<string>('');
+
+  // 다이얼로그 닫히면 책 검색 결과 초기화
+  useEffect(() => {
+    if (selectedType !== 'review') {
+      setSelectedBook(null);
+      setSearchQuery('');
+    }
+  }, [selectedType]);
   return (
     <Dialog
       fullScreen
@@ -45,7 +68,80 @@ const PostingDialog = ({
           </IconButton>
         </Stack>
       </DialogTitle>
-      <DialogContent>{/* 포스트 작성 폼 컴포넌트 */}</DialogContent>
+      <DialogContent
+        sx={{
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '30px',
+          '&.MuiDialogContent-root': {
+            padding: '30px 20px',
+          },
+        }}
+      >
+        {/* 책 검색 */}
+        <BookSearchAutoComplete
+          searchQuery={searchQuery}
+          setSearchQuery={setSearchQuery}
+          selectedBook={selectedBook}
+          setSelectedBook={setSelectedBook}
+        />
+        {/* 선택한 책 정보 추후 고유 id 뺼 예정 */}
+        {selectedBook && (
+          <Box sx={{ mb: 2 }}>
+            <Stack direction="row" spacing={2} alignItems="center">
+              <img
+                src={selectedBook.cover}
+                alt={selectedBook.title}
+                style={{ width: 60, height: 90 }}
+              />
+              <Stack>
+                <Typography>{selectedBook.title}</Typography>
+                <Typography variant="body2">{selectedBook.author}</Typography>
+                <Typography>{selectedBook.itemId}</Typography>
+              </Stack>
+            </Stack>
+          </Box>
+        )}
+        {/* 포스팅 제목 입력창 */}
+        <TextField
+          fullWidth
+          multiline
+          label="제목"
+          variant="outlined"
+          placeholder="제목을 입력하세요"
+          minRows={1}
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          sx={{
+            '& .MuiOutlinedInput-root': {
+              borderRadius: '8px',
+              height: '50px',
+              '& textarea': {
+                height: '100% !important',
+              },
+            },
+          }}
+        />
+        <TextEditor value={content} setValue={setContent} height="350px" />
+      </DialogContent>
+      <DialogActions
+        sx={{
+          justifyContent: 'center',
+          padding: '0',
+        }}
+      >
+        <Button
+          variant="contained"
+          sx={{
+            margin: '0',
+            width: '100%',
+            padding: '10px',
+            borderRadius: '0px 0px 10px 10px',
+          }}
+        >
+          한줄평 작성
+        </Button>{' '}
+      </DialogActions>
     </Dialog>
   );
 };

--- a/src/components/FeedPage/PostingDialog.tsx
+++ b/src/components/FeedPage/PostingDialog.tsx
@@ -16,6 +16,7 @@ import React, { useEffect, useState } from 'react';
 import { PostType } from './WriteDialog';
 import TextEditor from '@components/commons/TextEditor';
 import BookSearchAutoComplete from '@components/commons/BookSearchAutoComplete';
+import { Book } from '@shared/types/type';
 
 interface PostingDialogProps {
   handleBack: () => void;
@@ -29,12 +30,7 @@ const PostingDialog = ({
   handleBack,
 }: PostingDialogProps) => {
   const [searchQuery, setSearchQuery] = useState('');
-  const [selectedBook, setSelectedBook] = useState<null | {
-    title: string;
-    itemId: number;
-    author: string;
-    cover: string;
-  }>(null);
+  const [selectedBook, setSelectedBook] = useState<Book | null>(null);
   const [title, setTitle] = useState<string>('');
   const [content, setContent] = useState<string>('');
 
@@ -90,12 +86,12 @@ const PostingDialog = ({
           <Box sx={{ mb: 2 }}>
             <Stack direction="row" spacing={2} alignItems="center">
               <img
-                src={selectedBook.cover}
-                alt={selectedBook.title}
+                src={selectedBook.imageUrl}
+                alt={selectedBook.bookTitle}
                 style={{ width: 60, height: 90 }}
               />
               <Stack>
-                <Typography>{selectedBook.title}</Typography>
+                <Typography>{selectedBook.bookTitle}</Typography>
                 <Typography variant="body2">{selectedBook.author}</Typography>
                 <Typography>{selectedBook.itemId}</Typography>
               </Stack>

--- a/src/components/FeedPage/PostingDialog.tsx
+++ b/src/components/FeedPage/PostingDialog.tsx
@@ -122,7 +122,7 @@ const PostingDialog = ({
             },
           }}
         />
-        <TextEditor value={content} setValue={setContent} height="350px" />
+        <TextEditor value={content} setValue={setContent} />
       </DialogContent>
       <DialogActions
         sx={{

--- a/src/components/FeedPage/PostingDialog.tsx
+++ b/src/components/FeedPage/PostingDialog.tsx
@@ -1,22 +1,10 @@
-import {
-  Box,
-  Button,
-  Dialog,
-  DialogActions,
-  DialogContent,
-  DialogTitle,
-  IconButton,
-  Stack,
-  TextField,
-  Typography,
-} from '@mui/material';
-import ArrowBackIcon from '@mui/icons-material/ArrowBack';
-import CloseIcon from '@mui/icons-material/Close';
+import { Box, Stack, TextField, Typography } from '@mui/material';
 import React, { useEffect, useState } from 'react';
 import { PostType } from './WriteDialog';
 import TextEditor from '@components/commons/TextEditor';
 import BookSearchAutoComplete from '@components/commons/BookSearchAutoComplete';
 import { Book } from '@shared/types/type';
+import HybridDialog from '@components/commons/HybridDialog';
 
 interface PostingDialogProps {
   handleBack: () => void;
@@ -41,105 +29,74 @@ const PostingDialog = ({
       setSearchQuery('');
     }
   }, [selectedType]);
-  return (
-    <Dialog
-      fullScreen
-      open={selectedType === 'post'}
-      onClose={() => setSelectedType(null)}
-    >
-      <DialogTitle>
-        <Stack
-          direction="row"
-          justifyContent="space-between"
-          alignItems="center"
-        >
-          <Stack direction="row" alignItems="center" spacing={1}>
-            <IconButton onClick={handleBack}>
-              <ArrowBackIcon />
-            </IconButton>
-            <Typography>포스트 작성</Typography>
+
+  const contentNode = (
+    <Stack sx={{ gap: '30px' }}>
+      <BookSearchAutoComplete
+        searchQuery={searchQuery}
+        setSearchQuery={setSearchQuery}
+        selectedBook={selectedBook}
+        setSelectedBook={setSelectedBook}
+      />
+      {/* 선택한 책 정보 추후 고유 id 뺼 예정 */}
+      {selectedBook && (
+        <Box sx={{ mb: 2 }}>
+          <Stack direction="row" spacing={2} alignItems="center">
+            <img
+              src={selectedBook.imageUrl}
+              alt={selectedBook.bookTitle}
+              style={{ width: 60, height: 90 }}
+            />
+            <Stack>
+              <Typography>{selectedBook.bookTitle}</Typography>
+              <Typography variant="body2">{selectedBook.author}</Typography>
+              <Typography>{selectedBook.itemId}</Typography>
+            </Stack>
           </Stack>
-          <IconButton onClick={() => setSelectedType(null)}>
-            <CloseIcon />
-          </IconButton>
-        </Stack>
-      </DialogTitle>
-      <DialogContent
+        </Box>
+      )}
+      {/* 포스팅 제목 입력창 */}
+      <TextField
+        fullWidth
+        multiline
+        label="제목"
+        variant="outlined"
+        placeholder="제목을 입력하세요"
+        minRows={1}
+        value={title}
+        onChange={(e) => setTitle(e.target.value)}
         sx={{
+          '& .MuiOutlinedInput-root': {
+            borderRadius: '8px',
+            height: '50px',
+            '& textarea': {
+              height: '100% !important',
+            },
+          },
+        }}
+      />
+      <TextEditor value={content} setValue={setContent} />
+    </Stack>
+  );
+  return (
+    <HybridDialog
+      title="포스트 작성"
+      contentNode={contentNode}
+      open={selectedType === 'post'}
+      setOpen={() => setSelectedType(null)}
+      onBack={handleBack}
+      action="포스트 작성"
+      onActionClick={() => {}}
+      fullScreen
+      sx={{
+        '& .MuiDialogContent-root': {
           display: 'flex',
           flexDirection: 'column',
           gap: '30px',
-          '&.MuiDialogContent-root': {
-            padding: '30px 20px',
-          },
-        }}
-      >
-        {/* 책 검색 */}
-        <BookSearchAutoComplete
-          searchQuery={searchQuery}
-          setSearchQuery={setSearchQuery}
-          selectedBook={selectedBook}
-          setSelectedBook={setSelectedBook}
-        />
-        {/* 선택한 책 정보 추후 고유 id 뺼 예정 */}
-        {selectedBook && (
-          <Box sx={{ mb: 2 }}>
-            <Stack direction="row" spacing={2} alignItems="center">
-              <img
-                src={selectedBook.imageUrl}
-                alt={selectedBook.bookTitle}
-                style={{ width: 60, height: 90 }}
-              />
-              <Stack>
-                <Typography>{selectedBook.bookTitle}</Typography>
-                <Typography variant="body2">{selectedBook.author}</Typography>
-                <Typography>{selectedBook.itemId}</Typography>
-              </Stack>
-            </Stack>
-          </Box>
-        )}
-        {/* 포스팅 제목 입력창 */}
-        <TextField
-          fullWidth
-          multiline
-          label="제목"
-          variant="outlined"
-          placeholder="제목을 입력하세요"
-          minRows={1}
-          value={title}
-          onChange={(e) => setTitle(e.target.value)}
-          sx={{
-            '& .MuiOutlinedInput-root': {
-              borderRadius: '8px',
-              height: '50px',
-              '& textarea': {
-                height: '100% !important',
-              },
-            },
-          }}
-        />
-        <TextEditor value={content} setValue={setContent} />
-      </DialogContent>
-      <DialogActions
-        sx={{
-          justifyContent: 'center',
-          padding: '0',
-        }}
-      >
-        <Button
-          variant="contained"
-          sx={{
-            margin: '0',
-            width: '100%',
-            padding: '10px',
-            borderRadius: '0px 0px 10px 10px',
-          }}
-        >
-          한줄평 작성
-        </Button>{' '}
-      </DialogActions>
-    </Dialog>
+          padding: '30px 20px',
+        },
+      }}
+    />
   );
 };
-
 export default PostingDialog;

--- a/src/components/FeedPage/WriteDialog.tsx
+++ b/src/components/FeedPage/WriteDialog.tsx
@@ -3,6 +3,8 @@ import { Button, Stack } from '@mui/material';
 import { useState } from 'react';
 import PostingDialog from './PostingDialog';
 import OneLineReviewDialog from './OneLineReviewDialog';
+import PostAddIcon from '@mui/icons-material/PostAdd';
+import BorderColorIcon from '@mui/icons-material/BorderColor';
 
 export type PostType = 'post' | 'review' | null;
 
@@ -32,6 +34,7 @@ const WriteDialog = ({
       <Button
         variant="outlined"
         fullWidth
+        startIcon={<PostAddIcon />}
         onClick={() => handleTypeSelect('post')}
       >
         포스트 작성
@@ -39,6 +42,7 @@ const WriteDialog = ({
       <Button
         variant="outlined"
         fullWidth
+        startIcon={<BorderColorIcon />}
         onClick={() => handleTypeSelect('review')}
       >
         한줄평 작성

--- a/src/components/FeedPage/WriteDialog.tsx
+++ b/src/components/FeedPage/WriteDialog.tsx
@@ -55,7 +55,7 @@ const WriteDialog = ({
       <HybridDialog
         open={writeDialogOpen}
         setOpen={setWriteDialogOpen}
-        title=""
+        title="포스트 타입"
         contentNode={contentNode}
         maxWidth="xs"
       />

--- a/src/components/FeedPage/WriteDialog.tsx
+++ b/src/components/FeedPage/WriteDialog.tsx
@@ -1,0 +1,75 @@
+import HybridDialog from '@components/commons/HybridDialog';
+import { Button, Stack } from '@mui/material';
+import { useState } from 'react';
+import PostingDialog from './PostingDialog';
+import OneLineReviewDialog from './OneLineReviewDialog';
+
+export type PostType = 'post' | 'review' | null;
+
+interface WriteDialogProps {
+  writeDialogOpen: boolean;
+  setWriteDialogOpen: React.Dispatch<React.SetStateAction<boolean>>;
+}
+
+const WriteDialog = ({
+  writeDialogOpen,
+  setWriteDialogOpen,
+}: WriteDialogProps) => {
+  const [selectedType, setSelectedType] = useState<PostType>(null);
+
+  const handleTypeSelect = (type: PostType) => {
+    setSelectedType(type);
+    setWriteDialogOpen(false); // 첫 번째 모달 닫기
+  };
+
+  const handleBack = () => {
+    setSelectedType(() => null);
+    setWriteDialogOpen(true);
+  };
+
+  const contentNode = (
+    <Stack spacing={2}>
+      <Button
+        variant="outlined"
+        fullWidth
+        onClick={() => handleTypeSelect('post')}
+      >
+        포스트 작성
+      </Button>
+      <Button
+        variant="outlined"
+        fullWidth
+        onClick={() => handleTypeSelect('review')}
+      >
+        한줄평 작성
+      </Button>
+    </Stack>
+  );
+
+  return (
+    <>
+      <HybridDialog
+        open={writeDialogOpen}
+        setOpen={setWriteDialogOpen}
+        title=""
+        contentNode={contentNode}
+        maxWidth="xs"
+      />
+      {/* 포스팅 작성 모달 */}
+      <PostingDialog
+        handleBack={handleBack}
+        selectedType={selectedType}
+        setSelectedType={setSelectedType}
+      />
+
+      {/* 한줄평 작성 모달 */}
+      <OneLineReviewDialog
+        handleBack={handleBack}
+        selectedType={selectedType}
+        setSelectedType={setSelectedType}
+      />
+    </>
+  );
+};
+
+export default WriteDialog;

--- a/src/components/commons/BookSearchAutoComplete.tsx
+++ b/src/components/commons/BookSearchAutoComplete.tsx
@@ -1,4 +1,3 @@
-// BookSearch.tsx
 import { Autocomplete, Box, Stack, TextField, Typography } from '@mui/material';
 import { useSearchBooksQuery } from '@features/BookSearchPage/api/bookSearchApi';
 

--- a/src/components/commons/BookSearchAutoComplete.tsx
+++ b/src/components/commons/BookSearchAutoComplete.tsx
@@ -1,0 +1,84 @@
+// BookSearch.tsx
+import { Autocomplete, Box, Stack, TextField, Typography } from '@mui/material';
+import { useSearchBooksQuery } from '@features/BookSearchPage/api/bookSearchApi';
+
+interface BookSearchAutoCompleteProps {
+  searchQuery: string;
+  setSearchQuery: (query: string) => void;
+  selectedBook: {
+    title: string;
+    itemId: number;
+    author: string;
+    cover: string;
+  } | null;
+  setSelectedBook: (
+    book: {
+      title: string;
+      itemId: number;
+      author: string;
+      cover: string;
+    } | null,
+  ) => void;
+}
+
+const BookSearchAutoComplete = ({
+  searchQuery,
+  setSearchQuery,
+  setSelectedBook,
+}: BookSearchAutoCompleteProps) => {
+  const { data: searchResults } = useSearchBooksQuery(
+    {
+      query: searchQuery,
+      page: 1,
+      sort: 'Accuracy',
+    },
+    {
+      skip: !searchQuery,
+    },
+  );
+
+  return (
+    <>
+      <Autocomplete
+        fullWidth
+        options={searchResults?.item || []}
+        getOptionLabel={(option) => option.title}
+        onChange={(_, newValue) => {
+          setSelectedBook(newValue);
+        }}
+        renderOption={(props, option) => (
+          <Box component="li" {...props}>
+            <Stack direction="row" spacing={2} alignItems="center">
+              <img
+                src={option.cover}
+                alt={option.title}
+                style={{ width: 40, height: 60 }}
+              />
+              <Stack>
+                <Typography variant="body1">{option.title}</Typography>
+                <Typography variant="body2" color="text.secondary">
+                  {option.author}
+                </Typography>
+              </Stack>
+            </Stack>
+          </Box>
+        )}
+        renderInput={(params) => (
+          <TextField
+            {...params}
+            label="책 검색"
+            onChange={(e) => setSearchQuery(e.target.value)}
+            placeholder="책 제목을 입력하세요"
+            sx={{
+              '& .MuiOutlinedInput-root': {
+                borderRadius: '8px',
+              },
+            }}
+          />
+        )}
+      />
+    </>
+  );
+};
+
+export default BookSearchAutoComplete;

--- a/src/components/commons/BookSearchAutoComplete.tsx
+++ b/src/components/commons/BookSearchAutoComplete.tsx
@@ -1,23 +1,12 @@
 import { Autocomplete, Box, Stack, TextField, Typography } from '@mui/material';
 import { useSearchBooksQuery } from '@features/BookSearchPage/api/bookSearchApi';
+import { Book } from '@shared/types/type';
 
 interface BookSearchAutoCompleteProps {
   searchQuery: string;
   setSearchQuery: (query: string) => void;
-  selectedBook: {
-    title: string;
-    itemId: number;
-    author: string;
-    cover: string;
-  } | null;
-  setSelectedBook: (
-    book: {
-      title: string;
-      itemId: number;
-      author: string;
-      cover: string;
-    } | null,
-  ) => void;
+  selectedBook: Book | null;
+  setSelectedBook: (book: Book | null) => void;
 }
 
 const BookSearchAutoComplete = ({
@@ -43,7 +32,17 @@ const BookSearchAutoComplete = ({
         options={searchResults?.item || []}
         getOptionLabel={(option) => option.title}
         onChange={(_, newValue) => {
-          setSelectedBook(newValue);
+          if (newValue) {
+            const selectedBook: Book = {
+              bookTitle: newValue.title,
+              author: newValue.author,
+              imageUrl: newValue.cover,
+              itemId: newValue.itemId,
+            };
+            setSelectedBook(selectedBook);
+          } else {
+            setSelectedBook(null);
+          }
         }}
         renderOption={(props, option) => (
           <Box component="li" {...props}>

--- a/src/components/commons/HybridDialog.tsx
+++ b/src/components/commons/HybridDialog.tsx
@@ -12,13 +12,14 @@ import {
 } from '@mui/material';
 import CloseIcon from '@mui/icons-material/Close';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
-import { ReactNode } from 'react';
+import { ReactNode, useEffect } from 'react';
 
 interface BaseDialogProps extends DialogProps {
   title: string;
   contentNode: ReactNode;
   setOpen: React.Dispatch<React.SetStateAction<boolean>>;
   onBack?: () => void;
+  fullScreen?: boolean;
 }
 
 interface DialogWithActionProps extends BaseDialogProps {
@@ -42,6 +43,7 @@ const HybridDialog = ({
   open,
   setOpen,
   onBack,
+  fullScreen,
 }: HybridDialogProps): JSX.Element => {
   const handleClose = () => {
     setOpen(false);
@@ -52,6 +54,18 @@ const HybridDialog = ({
     onActionClick();
     handleClose();
   };
+  // FullScreen 다이얼로그가 오픈됐을 때, 바깥 영역의 스크롤바를 없앰
+  useEffect(() => {
+    if (open && fullScreen) {
+      document.body.style.overflow = 'hidden';
+    } else {
+      document.body.style.overflow = 'unset';
+    }
+
+    return () => {
+      document.body.style.overflow = 'unset';
+    };
+  }, [open, fullScreen]);
 
   return (
     <Dialog
@@ -61,9 +75,10 @@ const HybridDialog = ({
       open={open}
       onClose={handleClose}
       closeAfterTransition={false}
+      fullScreen={fullScreen}
       sx={{
         '& .MuiDialog-paper': {
-          borderRadius: '10px',
+          borderRadius: fullScreen ? '0px' : '10px',
         },
       }}
     >
@@ -113,7 +128,7 @@ const HybridDialog = ({
               margin: '0',
               width: '100%',
               padding: '0.5rem',
-              borderRadius: '0px 0px 10px 10px',
+              borderRadius: fullScreen ? '0px' : '0px 0px 10px 10px',
             }}
           >
             {action}

--- a/src/components/commons/HybridDialog.tsx
+++ b/src/components/commons/HybridDialog.tsx
@@ -1,4 +1,5 @@
 import {
+  Box,
   Button,
   Dialog,
   DialogActions,
@@ -10,12 +11,14 @@ import {
   Typography,
 } from '@mui/material';
 import CloseIcon from '@mui/icons-material/Close';
+import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import { ReactNode } from 'react';
 
 interface BaseDialogProps extends DialogProps {
   title: string;
   contentNode: ReactNode;
   setOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  onBack?: () => void;
 }
 
 interface DialogWithActionProps extends BaseDialogProps {
@@ -38,6 +41,7 @@ const HybridDialog = ({
   maxWidth = 'xs',
   open,
   setOpen,
+  onBack,
 }: HybridDialogProps): JSX.Element => {
   const handleClose = () => {
     setOpen(false);
@@ -45,7 +49,6 @@ const HybridDialog = ({
 
   const handleAction = () => {
     if (!onActionClick) return;
-
     onActionClick();
     handleClose();
   };
@@ -58,29 +61,67 @@ const HybridDialog = ({
       open={open}
       onClose={handleClose}
       closeAfterTransition={false}
+      sx={{
+        '& .MuiDialog-paper': {
+          borderRadius: '10px',
+        },
+      }}
     >
-      <DialogTitle>
+      <DialogTitle sx={{ padding: '0.5rem' }}>
         <Stack
           direction="row"
           justifyContent="space-between"
           alignItems="center"
         >
-          <Typography>{title}</Typography>
-          {!action && (
-            <IconButton size="small" onClick={handleClose}>
-              <CloseIcon />
+          {onBack ? (
+            <IconButton onClick={onBack}>
+              <ArrowBackIcon />
             </IconButton>
+          ) : (
+            // 뒤로가기 버튼만큼의 여백 > 타이틀 중앙에 오도록
+            <Box sx={{ width: 30 }} />
           )}
+          <Typography sx={{ textAlign: 'center' }}>{title}</Typography>
+          <IconButton onClick={handleClose}>
+            <CloseIcon />
+          </IconButton>
         </Stack>
       </DialogTitle>
-      <DialogContent>{contentNode}</DialogContent>
+      <DialogContent
+        sx={{
+          display: 'flex',
+          flexDirection: 'column',
+          '&.MuiDialogContent-root': {
+            padding: '1rem',
+          },
+        }}
+      >
+        {contentNode}
+      </DialogContent>
       {action && (
-        <DialogActions>
-          <Button onClick={handleClose}>취소</Button>
-          <Button onClick={handleAction}>{action}</Button>
+        <DialogActions
+          sx={{
+            justifyContent: 'center',
+            padding: '0',
+          }}
+        >
+          {/* 하단 전체를 차지하는 버튼 (1개의 Action) */}
+          <Button
+            variant="contained"
+            onClick={handleAction}
+            sx={{
+              margin: '0',
+              width: '100%',
+              padding: '0.5rem',
+              borderRadius: '0px 0px 10px 10px',
+            }}
+          >
+            {action}
+          </Button>
         </DialogActions>
       )}
     </Dialog>
   );
 };
+
 export default HybridDialog;

--- a/src/components/commons/TextEditor.tsx
+++ b/src/components/commons/TextEditor.tsx
@@ -1,0 +1,72 @@
+import ReactQuill from 'react-quill';
+import 'react-quill/dist/quill.snow.css';
+import { Box, styled } from '@mui/material';
+
+interface TextEditorProps {
+  value: string;
+  setValue: (value: string) => void;
+  width?: string;
+  height?: string;
+}
+
+const formats = [
+  'bold',
+  'italic',
+  'underline',
+  'strike',
+  'list',
+  'color',
+  'background',
+  'image',
+  'blockquote',
+  'code-block',
+];
+
+const modules = {
+  toolbar: [
+    [{ list: 'ordered' }, { list: 'bullet' }],
+    [],
+    ['bold', 'italic', 'underline', 'strike'],
+    [],
+    [{ color: [] }, { background: [] }],
+    [],
+    ['image', 'blockquote'],
+  ],
+};
+
+const TextEditorContainer = styled(Box)<{
+  editorWidth?: string;
+  editorHeight?: string;
+}>(({ editorWidth, editorHeight }) => ({
+  '& .ql-editor': {
+    width: editorWidth || '100%',
+    height: editorHeight || '300px',
+    backgroundColor: 'inherit',
+  },
+  '& .ql-container': {
+    borderRadius: '0 0 8px 8px',
+  },
+  '& .ql-toolbar': {
+    borderRadius: '8px 8px 0 0',
+  },
+}));
+
+const TextEditor = ({
+  value,
+  setValue,
+  width,
+  height,
+}: TextEditorProps): JSX.Element => {
+  return (
+    <TextEditorContainer editorWidth={width} editorHeight={height}>
+      <ReactQuill
+        value={value}
+        onChange={setValue}
+        formats={formats}
+        modules={modules}
+      />
+    </TextEditorContainer>
+  );
+};
+
+export default TextEditor;

--- a/src/components/commons/TextEditor.tsx
+++ b/src/components/commons/TextEditor.tsx
@@ -1,5 +1,5 @@
-import ReactQuill from 'react-quill';
-import 'react-quill/dist/quill.snow.css';
+import ReactQuill from 'react-quill-new';
+import 'react-quill-new/dist/quill.snow.css';
 import { Box, styled } from '@mui/material';
 
 interface TextEditorProps {

--- a/src/components/commons/TextEditor.tsx
+++ b/src/components/commons/TextEditor.tsx
@@ -5,8 +5,6 @@ import { Box, styled } from '@mui/material';
 interface TextEditorProps {
   value: string;
   setValue: (value: string) => void;
-  width?: string;
-  height?: string;
 }
 
 const formats = [
@@ -34,13 +32,10 @@ const modules = {
   ],
 };
 
-const TextEditorContainer = styled(Box)<{
-  editorWidth?: string;
-  editorHeight?: string;
-}>(({ editorWidth, editorHeight }) => ({
+const TextEditorContainer = styled(Box)(() => ({
   '& .ql-editor': {
-    width: editorWidth || '100%',
-    height: editorHeight || '300px',
+    width: '100%',
+    height: '300px',
     backgroundColor: 'inherit',
   },
   '& .ql-container': {
@@ -51,14 +46,9 @@ const TextEditorContainer = styled(Box)<{
   },
 }));
 
-const TextEditor = ({
-  value,
-  setValue,
-  width,
-  height,
-}: TextEditorProps): JSX.Element => {
+const TextEditor = ({ value, setValue }: TextEditorProps): JSX.Element => {
   return (
-    <TextEditorContainer editorWidth={width} editorHeight={height}>
+    <TextEditorContainer>
       <ReactQuill
         value={value}
         onChange={setValue}

--- a/src/pages/MainPage/Main.tsx
+++ b/src/pages/MainPage/Main.tsx
@@ -5,6 +5,7 @@ import {
   CircularProgress,
   Container,
   Divider,
+  Stack,
   Typography,
 } from '@mui/material';
 import Masonry from '@mui/lab/Masonry';
@@ -124,7 +125,7 @@ const Main = (): JSX.Element => {
         margin: '0 auto',
       }}
     >
-      <Box
+      <Stack
         sx={{
           display: 'flex',
           flexDirection: 'row',
@@ -144,7 +145,7 @@ const Main = (): JSX.Element => {
           writeDialogOpen={writeDialogOpen}
           setWriteDialogOpen={setWriteDialogOpen}
         />
-      </Box>
+      </Stack>
       <Box
         sx={{
           padding: '0 1rem',

--- a/src/pages/MainPage/Main.tsx
+++ b/src/pages/MainPage/Main.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import {
   Box,
+  Button,
   CircularProgress,
   Container,
   Divider,
@@ -25,6 +26,8 @@ import {
   generateRandomPostType,
   generateRandomTimeAgo,
 } from '@components/FeedPage/mockPosts';
+import CreateIcon from '@mui/icons-material/Create';
+import WriteDialog from '@components/FeedPage/WriteDialog';
 
 const Main = (): JSX.Element => {
   const [posts, setPosts] = useState<Post[]>(mockPosts);
@@ -32,8 +35,9 @@ const Main = (): JSX.Element => {
   const [postType, setPostType] = useState<PostType | ''>('');
   const [feedType, setFeedType] = useState<FeedType>('추천');
   const [filterKey, setFilterKey] = useState(0);
+  const [writeDialogOpen, setWriteDialogOpen] = useState(false);
   // 카드 표시 모드 설정
-  const isDetail: boolean = false;
+  const isDetail: boolean = true;
 
   // 포스트 타입 (한줄평 | 포스팅) 필터링 설정 > 추후 interface 확립 후 변경
   const handlePostTypeChange = (
@@ -120,6 +124,27 @@ const Main = (): JSX.Element => {
         margin: '0 auto',
       }}
     >
+      <Box
+        sx={{
+          display: 'flex',
+          flexDirection: 'row',
+          justifyContent: 'flex-end',
+          alignItems: 'center',
+          mb: '2rem',
+        }}
+      >
+        <Button
+          variant="outlined"
+          onClick={() => setWriteDialogOpen(true)}
+          endIcon={<CreateIcon />}
+        >
+          글쓰기
+        </Button>
+        <WriteDialog
+          writeDialogOpen={writeDialogOpen}
+          setWriteDialogOpen={setWriteDialogOpen}
+        />
+      </Box>
       <Box
         sx={{
           padding: '0 1rem',

--- a/src/shared/types/type.ts
+++ b/src/shared/types/type.ts
@@ -24,4 +24,5 @@ export interface Book {
   bookTitle: string;
   author: string;
   imageUrl: string;
+  itemId?: number;
 }


### PR DESCRIPTION
## 연관 이슈

- #47 #59 #34

## 작업 요약

- 포스트 작성 기능 구현

## 작업 상세 설명

- 포스트 타입 선택 다이얼로그 구현 (Hybrid Dialog 사용)
- 한줄평 작성 다이얼로그 구현
  - 별점 기능 추가 필요 (#56)
- 포스팅 작성 다이얼로그 구현
  - 포스팅 작성 후 포스팅 상세 페이지로 이동 (#55)
- 공통 컴포넌트
  - BookSearchAutoComplete 추가
    - 책 검색 위한 AutoComplete 검색창 구현
  - HybridDialog 변경
    - 뒤로가기 버튼 추가
    - 제목 상단 가운데 위치
    - 액션 버튼 전체 너비 차지하도록 하단 위치

## 리뷰 요구사항

- 리뷰 예상 시간: 10분
- 공통 컴포넌트 사용할 수도 있으니 그 부분 봐두시면 좋을 듯합니다.

## Preview 이미지 (필요시)
- 포스트 타입 선택 다이얼로그
![image](https://github.com/user-attachments/assets/88ca2ca4-fdd3-4b99-8c45-90ba532505e9)

- 한줄평 작성 다이얼로그
![image](https://github.com/user-attachments/assets/bdb441b1-5ada-4070-bc8b-110990005b1b)

- 포스팅 작성 다이얼로그
![image](https://github.com/user-attachments/assets/18e0d854-fec3-4cb3-bf2c-2e761af216ca)

- 책 검색 AutoComplete
![image](https://github.com/user-attachments/assets/f72fb42e-07d3-4fcb-8b78-c19f0fa8d99d)

