### PR TITLE
제목 없는 공통 다이얼로그 구현

### DIFF
--- a/src/components/FeedPage/WriteDialog.tsx
+++ b/src/components/FeedPage/WriteDialog.tsx
@@ -1,4 +1,4 @@
-import HybridDialog from '@components/commons/HybridDialog';
+import NonTitleDialog from '@components/commons/NonTitleDialog';
 import { Button, Stack } from '@mui/material';
 import { useState } from 'react';
 import PostingDialog from './PostingDialog';
@@ -30,7 +30,7 @@ const WriteDialog = ({
   };
 
   const contentNode = (
-    <Stack spacing={2}>
+    <Stack spacing={2} paddingY={2}>
       <Button
         variant="outlined"
         fullWidth
@@ -52,10 +52,9 @@ const WriteDialog = ({
 
   return (
     <>
-      <HybridDialog
+      <NonTitleDialog
         open={writeDialogOpen}
         setOpen={setWriteDialogOpen}
-        title="포스트 타입"
         contentNode={contentNode}
         maxWidth="xs"
       />

--- a/src/components/commons/HybridDialog.tsx
+++ b/src/components/commons/HybridDialog.tsx
@@ -27,12 +27,14 @@ interface DialogWithActionProps extends BaseDialogProps {
   onActionClick: () => void;
 }
 
-interface DialogWithOutActionProps extends BaseDialogProps {
+export interface DialogWithOutActionProps extends BaseDialogProps {
   action?: undefined;
   onActionClick?: never;
 }
 
-type HybridDialogProps = DialogWithActionProps | DialogWithOutActionProps;
+export type HybridDialogProps =
+  | DialogWithActionProps
+  | DialogWithOutActionProps;
 
 const HybridDialog = ({
   title,

--- a/src/components/commons/HybridDialog.tsx
+++ b/src/components/commons/HybridDialog.tsx
@@ -15,7 +15,7 @@ import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import { ReactNode, useEffect } from 'react';
 
 interface BaseDialogProps extends DialogProps {
-  title: string;
+  title?: string;
   contentNode: ReactNode;
   setOpen: React.Dispatch<React.SetStateAction<boolean>>;
   onBack?: () => void;
@@ -82,26 +82,28 @@ const HybridDialog = ({
         },
       }}
     >
-      <DialogTitle sx={{ padding: '0.5rem' }}>
-        <Stack
-          direction="row"
-          justifyContent="space-between"
-          alignItems="center"
-        >
-          {onBack ? (
-            <IconButton onClick={onBack}>
-              <ArrowBackIcon />
+      {title && (
+        <DialogTitle sx={{ padding: '0.5rem' }}>
+          <Stack
+            direction="row"
+            justifyContent="space-between"
+            alignItems="center"
+          >
+            {onBack ? (
+              <IconButton onClick={onBack}>
+                <ArrowBackIcon />
+              </IconButton>
+            ) : (
+              // 뒤로가기 버튼만큼의 여백 > 타이틀 중앙에 오도록
+              <Box sx={{ width: 30 }} />
+            )}
+            <Typography sx={{ textAlign: 'center' }}>{title}</Typography>
+            <IconButton onClick={handleClose}>
+              <CloseIcon />
             </IconButton>
-          ) : (
-            // 뒤로가기 버튼만큼의 여백 > 타이틀 중앙에 오도록
-            <Box sx={{ width: 30 }} />
-          )}
-          <Typography sx={{ textAlign: 'center' }}>{title}</Typography>
-          <IconButton onClick={handleClose}>
-            <CloseIcon />
-          </IconButton>
-        </Stack>
-      </DialogTitle>
+          </Stack>
+        </DialogTitle>
+      )}
       <DialogContent
         sx={{
           display: 'flex',

--- a/src/components/commons/HybridDialog.tsx
+++ b/src/components/commons/HybridDialog.tsx
@@ -85,7 +85,7 @@ const HybridDialog = ({
       }}
     >
       {title && (
-        <DialogTitle sx={{ padding: '0.5rem' }}>
+        <DialogTitle>
           <Stack
             direction="row"
             justifyContent="space-between"
@@ -106,34 +106,15 @@ const HybridDialog = ({
           </Stack>
         </DialogTitle>
       )}
-      <DialogContent
-        sx={{
-          display: 'flex',
-          flexDirection: 'column',
-          '&.MuiDialogContent-root': {
-            padding: '1rem',
-          },
-        }}
-      >
-        {contentNode}
-      </DialogContent>
+      <DialogContent>{contentNode}</DialogContent>
       {action && (
-        <DialogActions
-          sx={{
-            justifyContent: 'center',
-            padding: '0',
-          }}
-        >
+        <DialogActions sx={{ padding: 0 }}>
           {/* 하단 전체를 차지하는 버튼 (1개의 Action) */}
           <Button
             variant="contained"
             onClick={handleAction}
-            sx={{
-              margin: '0',
-              width: '100%',
-              padding: '0.5rem',
-              borderRadius: fullScreen ? '0px' : '0px 0px 10px 10px',
-            }}
+            fullWidth
+            sx={{ borderRadius: 0 }}
           >
             {action}
           </Button>

--- a/src/components/commons/NonTitleDialog.tsx
+++ b/src/components/commons/NonTitleDialog.tsx
@@ -1,0 +1,27 @@
+import HybridDialog, { DialogWithOutActionProps } from './HybridDialog';
+
+interface NonTitleDialogProps extends Omit<DialogWithOutActionProps, 'title'> {
+  title?: never;
+}
+
+const NonTitleDialog = ({
+  contentNode,
+  maxWidth,
+  open,
+  setOpen,
+  fullScreen,
+}: NonTitleDialogProps): JSX.Element => {
+  return (
+    <HybridDialog
+      contentNode={contentNode}
+      action="닫기"
+      onActionClick={() => setOpen(false)}
+      maxWidth={maxWidth}
+      open={open}
+      setOpen={setOpen}
+      fullScreen={fullScreen}
+    />
+  );
+};
+
+export default NonTitleDialog;


### PR DESCRIPTION
## 연관 이슈

- Close #89

## 작업 요약

- 제목 없는 공통 다이얼로그 구현하고 패딩 없애기 진행하였습니다.

## 리뷰어에게 전달 사항

- 제목 없는 다이얼로그 사용하고 싶으면 이제 `NonTitleDialog` 컴포넌트 사용하시면 됩니다! (추후 스토리북도 작성하면 어떤 다이얼로그가 있고 props에 따라 어떻게 활용 가능한 지 파악하기 용이할겁니다! 조금만 기다려주세용!)
- 액션 부분 패딩은 버튼이 전체 너비 차지하도록 디자인 되어있는 것 같아서, 이부분은 패딩 0 남겨두었습니다!
- @deenuit113 `WriteDialog`에도 반영해두었습니다! 또 사용되는 부분 있다면 참고해서 반영해주시면 될 것 같습니다.
- 일단 닫기 버튼 action으로 처리하긴 했는데, 타입 관련해서 처리할 때, 경우에 따른 필수값 처리하는 게 직관적이지 않은 경우가 있더라구요. 일단 title 항상 옵셔널하게 처리되어 있는데, 추후 배포까지 끝나고 시간이 남는다면 다시 설계 다듬고 리팩토링 작업 맡아서 해볼까 싶습니다!


## Preview 이미지 (필요시)

<img width="400" alt="image" src="https://github.com/user-attachments/assets/1de7a0e6-beb7-4741-8da0-83d090cd041f" />
<img width="400" alt="image" src="https://github.com/user-attachments/assets/171cedd3-3025-48ef-bd0e-5386e2eecfe3" />
<img width="400" alt="image" src="https://github.com/user-attachments/assets/8bda4a41-b167-476f-a466-aa645c3dcb67" />
<img width="800" alt="image" src="https://github.com/user-attachments/assets/51183b71-4880-4297-be6a-bc12728f7ddf" />
