### PR TITLE
카카오 로그인 헤더 버튼 동작 이슈

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,7 @@ import { Provider } from 'react-redux';
 import AppRouter from './routes/index';
 import Header from '@components/Header/Header';
 import SnackBar from './components/Snackbar/SnackBar';
-import store from './store/store';
+import { store } from '@store/index';
 import './App.css';
 
 const AppContent = (): JSX.Element => {

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -6,7 +6,7 @@ import { styled } from '@mui/material/styles';
 import { Button, Menu, MenuItem } from '@mui/material';
 import { useSelector, useDispatch } from 'react-redux';
 import { RootState } from '@store/index';
-import { logoutSuccess } from '@store/userSlice/userSlice';
+import { logoutSuccess } from '@features/user/userSlice';
 
 const HeaderContainer = styled('header')(({ theme }) => ({
   display: 'flex',
@@ -46,7 +46,7 @@ const Header = (): JSX.Element => {
   const [showSearchBar, setShowSearchBar] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
-  const isLoggedIn = useSelector((state: RootState) => state.user.isLoggedIn);
+  const user = useSelector((state: RootState) => state.user);
   const navigate = useNavigate();
   const dispatch = useDispatch();
 
@@ -110,7 +110,7 @@ const Header = (): JSX.Element => {
             <SearchIcon />
           </IconWrapper>
         </SearchContainer>
-        {isLoggedIn ? (
+        {user.isLoggedIn ? (
           <div>
             <IconWrapper onClick={handleProfileClick}>
               <PersonIcon />

--- a/src/components/LoginSignupPage/Login.tsx
+++ b/src/components/LoginSignupPage/Login.tsx
@@ -11,25 +11,21 @@ import {
 } from '@mui/material';
 import { useNavigate } from 'react-router-dom';
 import PasswordInput from './PasswordInput';
-
-interface LoginProps {
-  onLogin: (userId: string) => void;
-}
-
-interface LoginMessage {
-  content: string;
-  isError: boolean;
-}
+import { useDispatch } from 'react-redux';
+import { loginSuccess } from '@features/user/userSlice';
 
 const KAKAO_CLIENT_ID = import.meta.env.VITE_KAKAO_REST_API_KEY;
 const KAKAO_REDIRECT_URI = import.meta.env.VITE_KAKAO_REDIRECT_URI;
 
 const KAKAO_AUTH_URL = `https://kauth.kakao.com/oauth/authorize?client_id=${KAKAO_CLIENT_ID}&redirect_uri=${encodeURIComponent(KAKAO_REDIRECT_URI)}&response_type=code`;
 
-const Login = ({ onLogin }: LoginProps): JSX.Element => {
+const Login = (): JSX.Element => {
   const [userId, setUserId] = useState<string>('');
   const [password, setPassword] = useState<string>('');
-  const [loginMessage, setLoginMessage] = useState<LoginMessage>({
+  const [loginMessage, setLoginMessage] = useState<{
+    content: string;
+    isError: boolean;
+  }>({
     content: '',
     isError: false,
   });
@@ -37,6 +33,7 @@ const Login = ({ onLogin }: LoginProps): JSX.Element => {
   const [autoLogin, setAutoLogin] = useState<boolean>(false);
 
   const navigate = useNavigate();
+  const dispatch = useDispatch();
 
   const handleLogin = useCallback(
     (e: React.FormEvent<HTMLFormElement> | null) => {
@@ -53,7 +50,7 @@ const Login = ({ onLogin }: LoginProps): JSX.Element => {
         );
 
         if (user) {
-          onLogin(userId);
+          dispatch(loginSuccess());
           if (rememberMe) {
             localStorage.setItem('savedUserId', userId);
           } else {
@@ -81,7 +78,7 @@ const Login = ({ onLogin }: LoginProps): JSX.Element => {
         });
       }
     },
-    [userId, password, rememberMe, autoLogin, onLogin, navigate],
+    [userId, password, rememberMe, autoLogin, navigate, dispatch],
   );
 
   const handleRememberMeChange = (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/src/features/SNSLogin/auth/KakaoCallback.tsx
+++ b/src/features/SNSLogin/auth/KakaoCallback.tsx
@@ -1,12 +1,15 @@
 import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useDispatch } from 'react-redux';
 import { useGetKakaoTokenMutation } from '@features/SNSLogin/api/Kakaoapi';
+import { loginSuccess } from '@features/user/userSlice';
 
 const REST_API_KEY = import.meta.env.VITE_KAKAO_REST_API_KEY;
 const REDIRECT_URI = import.meta.env.VITE_KAKAO_REDIRECT_URI;
 
 const KakaoCallback = (): JSX.Element => {
   const navigate = useNavigate();
+  const dispatch = useDispatch();
   const [getKakaoToken, { data: tokenData, isLoading, error }] =
     useGetKakaoTokenMutation();
 
@@ -24,9 +27,10 @@ const KakaoCallback = (): JSX.Element => {
   useEffect(() => {
     if (tokenData) {
       console.log('Access Token:', tokenData.access_token);
+      dispatch(loginSuccess()); // Redux 상태 업데이트
       navigate('/');
     }
-  }, [tokenData, navigate]);
+  }, [tokenData, navigate, dispatch]);
 
   if (isLoading) return <div>Loading...</div>;
   if (error) return <div>Error occurred</div>;

--- a/src/features/user/userSlice.ts
+++ b/src/features/user/userSlice.ts
@@ -1,1 +1,22 @@
 // 유저 관련 slice
+import { createSlice } from '@reduxjs/toolkit';
+
+const initialState = {
+  isLoggedIn: false,
+};
+
+export const userSlice = createSlice({
+  name: 'user',
+  initialState,
+  reducers: {
+    loginSuccess: (state) => {
+      state.isLoggedIn = true;
+    },
+    logoutSuccess: (state) => {
+      state.isLoggedIn = false;
+    },
+  },
+});
+
+export const { loginSuccess, logoutSuccess } = userSlice.actions;
+export default userSlice.reducer;

--- a/src/store/index.tsx
+++ b/src/store/index.tsx
@@ -7,10 +7,11 @@ import { kakaoApi } from '@features/SNSLogin/api/Kakaoapi';
 import { bookDetailApi } from '@features/BookSearchPage/api/bookDetailApi';
 import bookDetailReducer from '@features/BookSearchPage/Slice/bookDetailSlice';
 import { libraryApi } from '@features/MyPage/api';
-import userReducer from './userSlice/userSlice';
+import userReducer from '@features/user/userSlice';
 import { bookShelvesApi } from '@features/BookShelvesPage/api/bookShelvesApi';
 import bookShelvesReducer from '@features/BookShelvesPage/slice/bookShelvesSlice';
 import { postingApi } from '@features/PostDetailPage/api/postingApi';
+import snackbarReducer from '@features/Snackbar/snackbarSlice';
 
 export const store = configureStore({
   reducer: {
@@ -26,6 +27,7 @@ export const store = configureStore({
     [postingApi.reducerPath]: postingApi.reducer,
     counter: counterReducer,
     user: userReducer,
+    snackbar: snackbarReducer,
   },
   middleware: (getDefaultMiddleware) =>
     getDefaultMiddleware().concat([


### PR DESCRIPTION
## 연관 이슈

> 연관된 이슈를 모두 기재 → #[Issue번호] 형식
- #23 
- #71 
- #79 
## 작업 요약

> 1~2줄 사이의 요약 설명
- 카카오 로그인 시 헤더가 동적으로 업데이트되지 않는 문제 수정
➕userSlice 파일을 이동, 스토어 파일 통합
## 작업 상세 설명

> 주요 기능 및 로직에 대한 설명을 작성
- 카카오 로그인 버튼 클릭 시 카카오 인증 URL로 리디렉션하는 로직 추가
- 사용자 정보를 로컬 스토리지에서 가져와 로그인 처리 후 Redux 상태를 업데이트하도록 수정
- 카카오 API로부터 받은 액세스 토큰을 사용하여 사용자 정보를 가져와 Redux 스토어에 저장
-> 로그인 상태에 따라 헤더의 로그인 버튼과 프로필 메뉴가 올바르게 렌더링되는것을 확인함
- store/userSlice 파일을 src/features/user 디렉토리로 이동하여 프로젝트 구조 개선
- store/store.tsx 파일을 store/index.tsx에 통합하여 스토어 관리 구조 간소화
## 리뷰 요구사항

> 리뷰 예상 시간 및 집중 리뷰 부분

리뷰 예상 시간: 10분 미만
집중 리뷰 부분: 카카오 로그인 처리 및 Redux 상태 업데이트 로직, 파일 이동에 따른 import 경로 변경 사항, 스토어 통합 및 경로 수정 사항 검토
## Preview 이미지 (필요시)

https://github.com/user-attachments/assets/f853d552-5f1f-4813-b2a7-fca9f544c5a1

