### PR TITLE
사용자 정보 수정 페이지 구현

### DIFF
--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -134,8 +134,8 @@ const Header = (): JSX.Element => {
               <MenuItem onClick={() => handleNavigation('/my-page')}>
                 마이페이지
               </MenuItem>
-              <MenuItem onClick={() => handleNavigation('/edit-profile')}>
-                프로필 편집
+              <MenuItem onClick={() => handleNavigation('/edit-account')}>
+                개인정보수정
               </MenuItem>
               <MenuItem onClick={handleLogout}>로그아웃</MenuItem>
             </Menu>

--- a/src/components/LoginSignupPage/Signup.tsx
+++ b/src/components/LoginSignupPage/Signup.tsx
@@ -16,6 +16,7 @@ import {
 import { useNavigate } from 'react-router-dom';
 import { useState } from 'react';
 import PasswordInput from './PasswordInput';
+import { User } from '@features/user/types';
 
 const schema = yup.object().shape({
   name: yup.string().required('이름을 입력해주세요'),
@@ -44,14 +45,8 @@ const schema = yup.object().shape({
     .integer('나이는 정수여야 합니다'),
 });
 
-interface SignupData {
-  name: string;
-  userId: string;
-  phone: string;
-  password: string;
+interface SignupData extends Omit<User, 'avatarUrl'> {
   confirmPassword: string;
-  gender: string;
-  age: number;
 }
 
 const Signup = (): JSX.Element => {

--- a/src/features/user/types.ts
+++ b/src/features/user/types.ts
@@ -1,0 +1,9 @@
+export interface User {
+  name: string;
+  userId: string;
+  phone: string;
+  password: string;
+  gender: string;
+  age: number;
+  avatarUrl: string;
+}

--- a/src/features/user/types.ts
+++ b/src/features/user/types.ts
@@ -7,3 +7,5 @@ export interface User {
   age: number;
   avatarUrl: string;
 }
+
+export type Account = Omit<User, 'gender' | 'age'>;

--- a/src/features/user/userApi.ts
+++ b/src/features/user/userApi.ts
@@ -1,0 +1,20 @@
+import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
+
+export const userApi = createApi({
+  reducerPath: 'userApi',
+  baseQuery: fetchBaseQuery({ baseUrl: '/api' }),
+  endpoints: (builder) => ({
+    passwordCheck: builder.mutation<
+      { success: boolean; message: string },
+      { userId: string; password: string }
+    >({
+      query: ({ userId, password }) => ({
+        url: `user/${userId}/password-check`,
+        method: 'POST',
+        body: { password },
+      }),
+    }),
+  }),
+});
+
+export const { usePasswordCheckMutation } = userApi;

--- a/src/features/user/userApi.ts
+++ b/src/features/user/userApi.ts
@@ -1,4 +1,5 @@
 import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
+import { Account } from './types';
 
 export const userApi = createApi({
   reducerPath: 'userApi',
@@ -14,7 +15,26 @@ export const userApi = createApi({
         body: { password },
       }),
     }),
+
+    getUserInfo: builder.query<Account, string>({
+      query: (userId) => `user/${userId}`,
+    }),
+
+    updateUserInfo: builder.mutation<
+      { success: boolean; message: string },
+      { userId: string; field: string; value: string }
+    >({
+      query: ({ userId, field, value }) => ({
+        url: `user/${userId}`,
+        method: 'PUT',
+        body: { [field]: value },
+      }),
+    }),
   }),
 });
 
-export const { usePasswordCheckMutation } = userApi;
+export const {
+  usePasswordCheckMutation,
+  useGetUserInfoQuery,
+  useUpdateUserInfoMutation,
+} = userApi;

--- a/src/features/user/userApi.ts
+++ b/src/features/user/userApi.ts
@@ -30,6 +30,32 @@ export const userApi = createApi({
         body: { [field]: value },
       }),
     }),
+
+    uploadAvatar: builder.mutation<
+      { success: boolean; message: string; avatarUrl: string },
+      { userId: string; file: File }
+    >({
+      query: ({ userId, file }) => {
+        const formData = new FormData();
+        formData.append('avatar', file);
+
+        return {
+          url: `user/${userId}/avatar`,
+          method: 'POST',
+          body: formData,
+        };
+      },
+    }),
+
+    deleteAvatar: builder.mutation<
+      { success: boolean; message: string },
+      string
+    >({
+      query: (userId) => ({
+        url: `user/${userId}/avatar`,
+        method: 'DELETE',
+      }),
+    }),
   }),
 });
 
@@ -37,4 +63,6 @@ export const {
   usePasswordCheckMutation,
   useGetUserInfoQuery,
   useUpdateUserInfoMutation,
+  useUploadAvatarMutation,
+  useDeleteAvatarMutation,
 } = userApi;

--- a/src/features/user/userSlice.ts
+++ b/src/features/user/userSlice.ts
@@ -1,8 +1,13 @@
-// 유저 관련 slice
-import { createSlice } from '@reduxjs/toolkit';
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
-const initialState = {
+export interface UserState {
+  isLoggedIn: boolean;
+  checkedPassword: boolean;
+}
+
+const initialState: UserState = {
   isLoggedIn: false,
+  checkedPassword: false,
 };
 
 export const userSlice = createSlice({
@@ -15,8 +20,12 @@ export const userSlice = createSlice({
     logoutSuccess: (state) => {
       state.isLoggedIn = false;
     },
+    setCheckedPassword(state, action: PayloadAction<boolean>) {
+      state.checkedPassword = action.payload;
+    },
   },
 });
 
-export const { loginSuccess, logoutSuccess } = userSlice.actions;
+export const { loginSuccess, logoutSuccess, setCheckedPassword } =
+  userSlice.actions;
 export default userSlice.reducer;

--- a/src/mocks/handlers/user.ts
+++ b/src/mocks/handlers/user.ts
@@ -99,4 +99,27 @@ export const userHandlers = [
       ],
     });
   }),
+  http.post('/api/user/:userId/password-check', async ({ request }) => {
+    const { password } = (await request.json()) as { password: string };
+
+    const isPasswordCorrect = password === 'P@ssw0rd1!';
+
+    if (isPasswordCorrect) {
+      return HttpResponse.json(
+        {
+          success: true,
+          message: '비밀번호 확인 완료',
+        },
+        { status: 200 },
+      );
+    }
+
+    return HttpResponse.json(
+      {
+        success: false,
+        message: '비밀번호가 일치하지 않습니다.',
+      },
+      { status: 401 },
+    );
+  }),
 ];

--- a/src/mocks/handlers/user.ts
+++ b/src/mocks/handlers/user.ts
@@ -161,9 +161,7 @@ export const userHandlers = [
     );
   }),
 
-  http.post('/api/user/:userId/avatar', async ({ params, request }) => {
-    const { userId } = params;
-
+  http.post('/api/user/:userId/avatar', async ({ request }) => {
     const formData = await request.formData();
     const file = formData.get('avatar');
 

--- a/src/mocks/handlers/user.ts
+++ b/src/mocks/handlers/user.ts
@@ -160,4 +160,40 @@ export const userHandlers = [
       { status: 200 },
     );
   }),
+
+  http.post('/api/user/:userId/avatar', async ({ params, request }) => {
+    const { userId } = params;
+
+    const formData = await request.formData();
+    const file = formData.get('avatar');
+
+    if (!file || !(file instanceof File)) {
+      return HttpResponse.json(
+        {
+          success: false,
+          message: '올바른 이미지를 업로드해주세요.',
+        },
+        { status: 400 },
+      );
+    }
+
+    return HttpResponse.json(
+      {
+        success: true,
+        message: '성공적으로 업로드되었습니다.',
+        avatarUrl: mockUser.avatarUrl,
+      },
+      { status: 200 },
+    );
+  }),
+
+  http.delete('/api/user/:userId/avatar', async () => {
+    return HttpResponse.json(
+      {
+        success: true,
+        message: '성공적으로 삭제되었습니다.',
+      },
+      { status: 200 },
+    );
+  }),
 ];

--- a/src/mocks/handlers/user.ts
+++ b/src/mocks/handlers/user.ts
@@ -1,5 +1,12 @@
 import { http, HttpResponse } from 'msw';
 
+const mockUser = {
+  userId: 'user',
+  name: '김구름',
+  phone: '010-1234-5678',
+  avatarUrl: 'https://github.com/publdaze.png',
+};
+
 export const userHandlers = [
   http.get(`/api/user/:userId/feeds`, () => {
     return HttpResponse.json({
@@ -8,40 +15,40 @@ export const userHandlers = [
           title: '2월은 결심하기 좋은 자기계발의 달!',
           content:
             '2024년에도 어김없이 결심의 시즌이 돌아왔습니다! 여러분을 위한 특별한 추천 도서를 소개합니다.',
-          author: '김독서',
+          author: mockUser.name,
           avatar: '/path/to/avatar1.jpg',
         },
         {
           title: '✨ 2024 상반기 결산 - 책복/도슨트북',
           content:
             '밀리에서 전자책 외에다양한 독서 콘텐츠를 빼놓을 수 없죠! 😉밀리는 회원들의 일상생활에 독서가 1밀리 더스며들 수 있도록 다양한 도전을 이어가고 있어요. 챗북부터 도슨트북, 오브제북, 영상 콘텐츠까지!2024년 상반기에도 책을 쉽고, 재밌고, 풍성하게접할 수 있는 새로운 콘텐츠들이 쏟아졌는데요.과연 그중 어떤 콘텐츠가 주목받았는지함께 확인해 볼까요? 2024년의 상반기, 밀리 회원들이 좋아한 콘텐츠 랭킹을 보면 인간관계에 대한 관심이 높아진 것',
-          author: '김독서',
+          author: mockUser.name,
           avatar: '/path/to/avatar1.jpg',
         },
         {
           title: '좋아하는 것들',
           content: '나만의 취향을 담은 독서 추천, 여러분과 함께 하고 싶어요.',
-          author: '김독서',
+          author: mockUser.name,
           avatar: '/path/to/avatar1.jpg',
         },
       ],
       reviews: [
         {
-          username: '김독서',
+          username: mockUser.name,
           date: '2024.08.01',
           content: '새롭네요!',
           likes: 1,
           rating: 4, // 별점 추가
         },
         {
-          username: '김독서',
+          username: mockUser.name,
           date: '2024.02.27',
           content: '도슨트북 새롭고 재미있어요',
           likes: 1,
           rating: 5, // 별점 추가
         },
         {
-          username: '김독서',
+          username: mockUser.name,
           date: '2024.10.16',
           content: '책에 더 흥미를 갖게 도와주는 것 같아요',
           likes: 1,
@@ -120,6 +127,37 @@ export const userHandlers = [
         message: '비밀번호가 일치하지 않습니다.',
       },
       { status: 401 },
+    );
+  }),
+
+  http.get('/api/user/:userId', ({ params }) => {
+    const { userId } = params;
+
+    return HttpResponse.json(
+      {
+        userId,
+        name: mockUser.name,
+        phone: mockUser.phone,
+        avatarUrl: mockUser.avatarUrl,
+      },
+      { status: 200 },
+    );
+  }),
+
+  http.put('/api/user/:userId', async ({ params, request }) => {
+    const { userId } = params;
+    const updatedField = (await request.json()) as Partial<typeof mockUser>;
+
+    return HttpResponse.json(
+      {
+        success: true,
+        message: '개인 정보 수정이 완료되었습니다.',
+        data: {
+          userId,
+          ...updatedField,
+        },
+      },
+      { status: 200 },
     );
   }),
 ];

--- a/src/pages/EditAccountPage.tsx/EditAccountPage.tsx
+++ b/src/pages/EditAccountPage.tsx/EditAccountPage.tsx
@@ -147,7 +147,7 @@ const EditAccountPage = (): JSX.Element => {
 
   return (
     <Container maxWidth="sm" sx={{ mt: 6 }}>
-      <Stack alignItems="center" spacing={1} mb={4}>
+      <Stack alignItems="center" spacing={1} mb={3}>
         <Avatar
           src={userInfoState.avatarUrl}
           alt="avatar"
@@ -175,8 +175,14 @@ const EditAccountPage = (): JSX.Element => {
       </Stack>
 
       <Stack>
-        <Typography variant="h6" fontWeight="bold" mb={4}>
-          개인정보 수정
+        <Stack alignItems="center">
+          <Typography variant="h6" fontWeight="bold" mb={4}>
+            개인정보 수정
+          </Typography>
+        </Stack>
+
+        <Typography variant="subtitle1" fontWeight="bold" mb={1}>
+          회원 정보
         </Typography>
 
         <Stack direction="row" alignItems="center" spacing={1} mb={3}>

--- a/src/pages/EditAccountPage.tsx/EditAccountPage.tsx
+++ b/src/pages/EditAccountPage.tsx/EditAccountPage.tsx
@@ -1,0 +1,163 @@
+import React, { useEffect, useState } from 'react';
+import {
+  Container,
+  Typography,
+  Avatar,
+  TextField,
+  Button,
+  Stack,
+  IconButton,
+  styled,
+} from '@mui/material';
+import CameraAltIcon from '@mui/icons-material/CameraAlt';
+import DeleteIcon from '@mui/icons-material/Delete';
+import { useNavigate } from 'react-router-dom';
+import { useSelector } from 'react-redux';
+import { RootState } from '@store/index';
+import { User } from '@features/user/types';
+
+const VisuallyHiddenInput = styled('input')({
+  clip: 'rect(0 0 0 0)',
+  clipPath: 'inset(50%)',
+  height: 1,
+  overflow: 'hidden',
+  position: 'absolute',
+  bottom: 0,
+  left: 0,
+  whiteSpace: 'nowrap',
+  width: 1,
+});
+
+type ACCOUNT = Omit<User, 'gender' | 'age'>;
+
+const EditAccountPage = (): JSX.Element => {
+  const [userInfo, setUserInfo] = useState<ACCOUNT>({
+    name: '김구름',
+    userId: 'publ***',
+    phone: '010****4561',
+    password: '',
+    avatarUrl: '',
+  });
+
+  const checkedPassword = useSelector(
+    (state: RootState) => state.user.checkedPassword,
+  );
+
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (!checkedPassword) navigate('/edit-account/passwordChk');
+  }, [checkedPassword, navigate]);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    setUserInfo((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = (field: string) => {
+    console.log(field);
+  };
+
+  return (
+    <Container maxWidth="sm" sx={{ mt: 6 }}>
+      <Stack alignItems="center" spacing={1} mb={4}>
+        <Avatar
+          src={userInfo.avatarUrl}
+          alt="avatar"
+          sx={{
+            width: 96,
+            height: 96,
+          }}
+        />
+        <Stack direction="row" spacing={1}>
+          <IconButton component="label">
+            <CameraAltIcon />
+            <VisuallyHiddenInput
+              type="file"
+              onChange={(event) => console.log(event.target.files)}
+            />
+          </IconButton>
+          <IconButton>
+            <DeleteIcon />
+          </IconButton>
+        </Stack>
+      </Stack>
+
+      <Stack>
+        <Typography variant="h6" fontWeight="bold" mb={4}>
+          개인정보 수정
+        </Typography>
+
+        <Stack direction="row" alignItems="center" spacing={1} mb={3}>
+          <TextField
+            fullWidth
+            label="이름"
+            name="nickname"
+            value={userInfo.name}
+            onChange={handleChange}
+          />
+          <Button
+            variant="contained"
+            color="primary"
+            sx={{ width: '100px', height: '50px' }}
+            onClick={() => handleSubmit('이름')}
+          >
+            변경하기
+          </Button>
+        </Stack>
+
+        <Stack direction="row" alignItems="center" spacing={1} mb={3}>
+          <TextField
+            fullWidth
+            label="휴대폰 번호"
+            name="phone"
+            value={userInfo.phone}
+            onChange={handleChange}
+          />
+          <Button
+            variant="contained"
+            color="primary"
+            sx={{ width: '100px', height: '50px' }}
+            onClick={() => handleSubmit('휴대폰 번호')}
+          >
+            변경하기
+          </Button>
+        </Stack>
+
+        <Typography variant="subtitle1" fontWeight="bold" mb={1}>
+          계정 정보
+        </Typography>
+
+        <TextField
+          sx={{ mb: 3 }}
+          fullWidth
+          label="아이디"
+          name="userId"
+          value={userInfo.userId}
+          disabled
+        />
+
+        <Stack direction="row" alignItems="center" spacing={1} mb={3}>
+          <TextField
+            fullWidth
+            type="password"
+            label="비밀번호"
+            name="password"
+            value={userInfo.password}
+            onChange={handleChange}
+          />
+          <Button
+            variant="contained"
+            color="primary"
+            sx={{ width: '100px', height: '50px' }}
+            onClick={() => handleSubmit('비밀번호')}
+          >
+            변경하기
+          </Button>
+        </Stack>
+      </Stack>
+    </Container>
+  );
+};
+
+export default EditAccountPage;

--- a/src/pages/PasswordChkPage/PasswordChkPage.tsx
+++ b/src/pages/PasswordChkPage/PasswordChkPage.tsx
@@ -20,13 +20,7 @@ const PasswordChkPage = () => {
   const [passwordCheck] = usePasswordCheckMutation();
   const dispatch = useDispatch<AppDispatch>();
 
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setPassword(e.target.value);
-  };
-
-  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-
+  const handlePasswordCheck = async () => {
     try {
       const result = await passwordCheck({
         userId: 'user123',
@@ -41,6 +35,21 @@ const PasswordChkPage = () => {
     } catch {
       console.error('비밀번호 확인 중 오류가 발생했습니다.');
     }
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      handlePasswordCheck();
+    }
+  };
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setPassword(e.target.value);
+  };
+
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    handlePasswordCheck();
   };
 
   return (
@@ -72,6 +81,7 @@ const PasswordChkPage = () => {
           name="password"
           value={password}
           onChange={handleChange}
+          onKeyDown={handleKeyDown}
           variant="outlined"
           sx={{ mb: 3 }}
         />

--- a/src/pages/PasswordChkPage/PasswordChkPage.tsx
+++ b/src/pages/PasswordChkPage/PasswordChkPage.tsx
@@ -8,9 +8,15 @@ import {
 } from '@mui/material';
 import LockIcon from '@mui/icons-material/Lock';
 import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useDispatch } from 'react-redux';
+import { AppDispatch } from '@store/index';
+import { setCheckedPassword } from '@features/user/userSlice';
 
 const PasswordChkPage = () => {
   const [password, setPassword] = useState('');
+  const navigate = useNavigate();
+  const dispatch = useDispatch<AppDispatch>();
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setPassword(e.target.value);
@@ -18,6 +24,10 @@ const PasswordChkPage = () => {
 
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
+
+    /* TODO API 연결 */
+    dispatch(setCheckedPassword(true));
+    navigate('/edit-account');
   };
 
   return (

--- a/src/pages/PasswordChkPage/PasswordChkPage.tsx
+++ b/src/pages/PasswordChkPage/PasswordChkPage.tsx
@@ -13,6 +13,8 @@ import { useDispatch } from 'react-redux';
 import { AppDispatch } from '@store/index';
 import { setCheckedPassword } from '@features/user/userSlice';
 import { usePasswordCheckMutation } from '@features/user/userApi';
+import { showSnackbar } from '@features/Snackbar/snackbarSlice';
+import { FetchBaseQueryError } from '@reduxjs/toolkit/query/react';
 
 const PasswordChkPage = () => {
   const [password, setPassword] = useState('');
@@ -30,10 +32,17 @@ const PasswordChkPage = () => {
         dispatch(setCheckedPassword(true));
         navigate('/edit-account');
       } else {
-        console.error(result.message);
+        dispatch(showSnackbar({ message: result.message, severity: 'error' }));
       }
-    } catch {
-      console.error('비밀번호 확인 중 오류가 발생했습니다.');
+    } catch (err) {
+      const error = err as FetchBaseQueryError;
+
+      dispatch(
+        showSnackbar({
+          message: (error.data as { message: string }).message,
+          severity: 'error',
+        }),
+      );
     }
   };
 

--- a/src/pages/PasswordChkPage/PasswordChkPage.tsx
+++ b/src/pages/PasswordChkPage/PasswordChkPage.tsx
@@ -1,0 +1,69 @@
+import {
+  Avatar,
+  Typography,
+  TextField,
+  Button,
+  Container,
+  Stack,
+} from '@mui/material';
+import LockIcon from '@mui/icons-material/Lock';
+import { useState } from 'react';
+
+const PasswordChkPage = () => {
+  const [password, setPassword] = useState('');
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setPassword(e.target.value);
+  };
+
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+  };
+
+  return (
+    <Container maxWidth="sm" sx={{ mt: 6 }}>
+      <Stack textAlign="center" mb={4}>
+        <Avatar
+          sx={{
+            width: 96,
+            height: 96,
+            bgcolor: 'primary.main',
+            mx: 'auto',
+            mb: 2,
+          }}
+        >
+          <LockIcon sx={{ fontSize: 48, color: 'white' }} />
+        </Avatar>
+        <Typography variant="h5" fontWeight="bold">
+          비밀번호 확인
+        </Typography>
+        <Typography variant="body2" color="text.secondary">
+          안전한 개인정보 변경을 위해 비밀번호를 다시 입력해주세요.
+        </Typography>
+      </Stack>
+      <Stack component="form" onSubmit={handleSubmit}>
+        <TextField
+          fullWidth
+          type="password"
+          label="비밀번호 입력"
+          name="password"
+          value={password}
+          onChange={handleChange}
+          variant="outlined"
+          sx={{ mb: 3 }}
+        />
+        <Button
+          type="submit"
+          fullWidth
+          variant="contained"
+          color="primary"
+          sx={{ py: 1.5, fontWeight: 'bold' }}
+        >
+          확인
+        </Button>
+      </Stack>
+    </Container>
+  );
+};
+
+export default PasswordChkPage;

--- a/src/pages/PasswordChkPage/PasswordChkPage.tsx
+++ b/src/pages/PasswordChkPage/PasswordChkPage.tsx
@@ -12,22 +12,35 @@ import { useNavigate } from 'react-router-dom';
 import { useDispatch } from 'react-redux';
 import { AppDispatch } from '@store/index';
 import { setCheckedPassword } from '@features/user/userSlice';
+import { usePasswordCheckMutation } from '@features/user/userApi';
 
 const PasswordChkPage = () => {
   const [password, setPassword] = useState('');
   const navigate = useNavigate();
+  const [passwordCheck] = usePasswordCheckMutation();
   const dispatch = useDispatch<AppDispatch>();
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setPassword(e.target.value);
   };
 
-  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
-    /* TODO API 연결 */
-    dispatch(setCheckedPassword(true));
-    navigate('/edit-account');
+    try {
+      const result = await passwordCheck({
+        userId: 'user123',
+        password,
+      }).unwrap();
+      if (result.success) {
+        dispatch(setCheckedPassword(true));
+        navigate('/edit-account');
+      } else {
+        console.error(result.message);
+      }
+    } catch {
+      console.error('비밀번호 확인 중 오류가 발생했습니다.');
+    }
   };
 
   return (

--- a/src/pages/PasswordChkPage/PasswordChkPage.tsx
+++ b/src/pages/PasswordChkPage/PasswordChkPage.tsx
@@ -24,15 +24,17 @@ const PasswordChkPage = () => {
 
   const handlePasswordCheck = async () => {
     try {
-      const result = await passwordCheck({
+      const response = await passwordCheck({
         userId: 'user123',
         password,
       }).unwrap();
-      if (result.success) {
+      if (response.success) {
         dispatch(setCheckedPassword(true));
         navigate('/edit-account');
       } else {
-        dispatch(showSnackbar({ message: result.message, severity: 'error' }));
+        dispatch(
+          showSnackbar({ message: response.message, severity: 'error' }),
+        );
       }
     } catch (err) {
       const error = err as FetchBaseQueryError;

--- a/src/routes/RoutePath.ts
+++ b/src/routes/RoutePath.ts
@@ -5,6 +5,7 @@ const RoutePaths = {
   FEED: '/feed',
   SEARCH: '/search',
   MY_PAGE: '/my-page',
+  EDIT_ACCOUNT: '/edit-account',
   BOOKSHELVES: '/bookshelves',
   POSTING: '/posting',
   POSTING_WRITE: '/posting/write',

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -11,6 +11,7 @@ import PostingDetailPage from '@pages/PostingDetailPage/PostingDetailPage';
 import BookDetailPage from '@pages/BookDetailPage/BookDetailPage';
 import ReviewMorePage from '@pages/ReviewMorePage/ReviewMorePage';
 import PostMorePage from '@pages/PostMorePage/PostMorePage';
+import EditAccountPage from '@pages/EditAccountPage.tsx/EditAccountPage';
 import PasswordChkPage from '@pages/PasswordChkPage/PasswordChkPage';
 import KakaoCallback from '@features/SNSLogin/auth/KakaoCallback';
 import PostingWritePage from '@pages/PostingWritePage/PostingWritePage';
@@ -27,6 +28,10 @@ const AppRouter = () => {
       <Route
         path={`${RoutePaths.EDIT_ACCOUNT}/passwordChk`}
         element={<PasswordChkPage />}
+      />
+      <Route
+        path={`${RoutePaths.EDIT_ACCOUNT}`}
+        element={<EditAccountPage />}
       />
       <Route
         path={`${RoutePaths.BOOKDETAIL}/:itemId`}

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -25,6 +25,7 @@ const AppRouter = () => {
       <Route path={RoutePaths.FEED} element={<FeedPage />} />
       <Route path={RoutePaths.SEARCH} element={<BookSearchPage />} />
       <Route path={`${RoutePaths.MY_PAGE}/:userId?`} element={<MyPage />} />
+      <Route path="/oauth/kakao" element={<KakaoCallback />} />
       <Route
         path={`${RoutePaths.EDIT_ACCOUNT}/passwordChk`}
         element={<PasswordChkPage />}

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -11,6 +11,7 @@ import PostingDetailPage from '@pages/PostingDetailPage/PostingDetailPage';
 import BookDetailPage from '@pages/BookDetailPage/BookDetailPage';
 import ReviewMorePage from '@pages/ReviewMorePage/ReviewMorePage';
 import PostMorePage from '@pages/PostMorePage/PostMorePage';
+import PasswordChkPage from '@pages/PasswordChkPage/PasswordChkPage';
 import KakaoCallback from '@features/SNSLogin/auth/KakaoCallback';
 import PostingWritePage from '@pages/PostingWritePage/PostingWritePage';
 
@@ -23,7 +24,10 @@ const AppRouter = () => {
       <Route path={RoutePaths.FEED} element={<FeedPage />} />
       <Route path={RoutePaths.SEARCH} element={<BookSearchPage />} />
       <Route path={`${RoutePaths.MY_PAGE}/:userId?`} element={<MyPage />} />
-      <Route path="/oauth/kakao" element={<KakaoCallback />} />
+      <Route
+        path={`${RoutePaths.EDIT_ACCOUNT}/passwordChk`}
+        element={<PasswordChkPage />}
+      />
       <Route
         path={`${RoutePaths.BOOKDETAIL}/:itemId`}
         element={<BookDetailPage />}

--- a/src/store/index.tsx
+++ b/src/store/index.tsx
@@ -19,6 +19,7 @@ import { userFeedsApi } from '@features/MyPage/api/userFeedsApi';
 import { feedApi } from '@features/FeedPage/api/feedApi';
 import { oneLineReviewApi } from '@features/OneLineReviewDialog/api/oneLineReviewApi';
 import { postingWriteApi } from '@features/PostingWritePage/api/postingWriteApi';
+import { userApi } from '@features/user/userApi';
 
 import { addToLibraryApi } from '@features/BookDetailPage/api/AddToLibraryApi';
 import { bookUserShelfCountApi } from '@features/BookDetailPage/api/bookUserShelfCountApi';
@@ -40,9 +41,10 @@ export const store = configureStore({
     [reviewApi.reducerPath]: reviewApi.reducer,
     [addToLibraryApi.reducerPath]: addToLibraryApi.reducer,
     [bookUserShelfCountApi.reducerPath]: bookUserShelfCountApi.reducer,
-    [feedApi.reducerPath]: feedApi.reducer,
     [oneLineReviewApi.reducerPath]: oneLineReviewApi.reducer,
+    [feedApi.reducerPath]: feedApi.reducer,
     [postingWriteApi.reducerPath]: postingWriteApi.reducer,
+    [userApi.reducerPath]: userApi.reducer,
     counter: counterReducer,
     user: userReducer,
     snackbar: snackbarReducer,
@@ -65,6 +67,7 @@ export const store = configureStore({
       feedApi.middleware,
       oneLineReviewApi.middleware,
       postingWriteApi.middleware,
+      userApi.middleware,
     ]),
 });
 

--- a/src/store/userSlice/userSlice.tsx
+++ b/src/store/userSlice/userSlice.tsx
@@ -1,7 +1,13 @@
-import { createSlice } from '@reduxjs/toolkit';
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
-const initialState = {
+export interface UserState {
+  isLoggedIn: boolean;
+  checkedPassword: boolean;
+}
+
+const initialState: UserState = {
   isLoggedIn: false,
+  checkedPassword: false,
 };
 
 export const userSlice = createSlice({
@@ -14,8 +20,12 @@ export const userSlice = createSlice({
     logoutSuccess: (state) => {
       state.isLoggedIn = false;
     },
+    setCheckedPassword(state, action: PayloadAction<boolean>) {
+      state.checkedPassword = action.payload;
+    },
   },
 });
 
-export const { loginSuccess, logoutSuccess } = userSlice.actions;
+export const { loginSuccess, logoutSuccess, setCheckedPassword } =
+  userSlice.actions;
 export default userSlice.reducer;


### PR DESCRIPTION
## 연관 이슈

- #93

## 작업 요약

- 사용자 정보 수정 페이지 구현하였습니다.

## 작업 상세 설명

[비밀번호확인 페이지]
- 개인 정보 수정으로 들어갔을 때, 비밀번호 확인이 수행되지 않은 경우에는 비밀번호 확인을 먼저 진행할 수 있도록 비밀번호 확인 페이지로 리다이렉트 됩니다.
- 목업 api로 비밀번호 확인하도록 구현하였습니다. (이때, 목업 비밀번호는 `P@ssw0rd1!`로 이와 동일할 경우 통과되도록 하였습니다.)
- 비밀번호가 틀릴 경우에는 스낵바를 통해 에러 메시지를 적용합니다.
- 비밀번호 확인이 성공적으로 수행되면 개인 정보 수정 페이지로 돌아갑니다.

[개인정보수정 페이지]
- 사용자 이름, 휴대폰 번호, 비밀번호를 개별적으로 수정할 수 있는 기능을 추가하였습니다. (목업 api 연동)
- 사용자 아바타 이미지를 업로드 및 삭제할 수 있는 기능 추가. (이때, 이미지를 실제 서버에 올리고 url을 받아올 수는 없어서 목업으로 한 url에 대한 처리만 가능합니다.)
- 각 요청 성공 및 실패 시 Snackbar를 활용하여 사용자에게 알림 표시되도록 하였습니다.


## 리뷰 요구사항

- 30분..?
- 개인정보수정 form에 대한 유효성 검사 이 PR 머지 후 별도 PR으로 올리겠습니다.

## Preview 이미지 (필요시)

https://github.com/user-attachments/assets/a511d64a-c682-44b5-8772-5636c25f10a4

