### PR TITLE
피드 탭 더보기 페이지 구현

### DIFF
--- a/src/components/MyPage/Feed/Feed.tsx
+++ b/src/components/MyPage/Feed/Feed.tsx
@@ -5,15 +5,16 @@ import ReviewFeedSection from './ReviewFeedSection';
 import PostFeedSection from './PostFeedSection';
 
 interface FeedProps {
+  userId: string;
   reviews: Review[];
   posts: Post[];
 }
 
-const Feed = ({ reviews, posts }: FeedProps): JSX.Element => {
+const Feed = ({ userId, reviews, posts }: FeedProps): JSX.Element => {
   return (
     <>
-      <ReviewFeedSection reviews={reviews} />
-      <PostFeedSection posts={posts} />
+      <ReviewFeedSection userId={userId} reviews={reviews} />
+      <PostFeedSection userId={userId} posts={posts} />
     </>
   );
 };

--- a/src/components/MyPage/Feed/LikedFeedTabPanel.tsx
+++ b/src/components/MyPage/Feed/LikedFeedTabPanel.tsx
@@ -12,7 +12,13 @@ const LikedFeedTabPanel = ({ userId }: LikedFeedTabPanelProps): JSX.Element => {
   if (isLoading) return <Typography>로딩 중...</Typography>;
   if (error) return <Typography>에러 발생: {JSON.stringify(error)}</Typography>;
 
-  return <>{feeds && <Feed posts={feeds.posts} reviews={feeds.reviews} />}</>;
+  return (
+    <>
+      {feeds && (
+        <Feed userId={userId} posts={feeds.posts} reviews={feeds.reviews} />
+      )}
+    </>
+  );
 };
 
 export default LikedFeedTabPanel;

--- a/src/components/MyPage/Feed/PostFeedSection.tsx
+++ b/src/components/MyPage/Feed/PostFeedSection.tsx
@@ -2,12 +2,19 @@ import { Post } from '@components/BookDetailPage/BookReviewTab';
 import PostCard from '@components/commons/DetailPagePostCard';
 import { Box, Typography, Button } from '@mui/material';
 import Grid from '@mui/material/Grid2';
+import { useNavigate } from 'react-router-dom';
 
 interface PostFeedSectionProps {
+  userId: string;
   posts: Post[];
 }
 
-const PostFeedSection = ({ posts }: PostFeedSectionProps): JSX.Element => {
+const PostFeedSection = ({
+  userId,
+  posts,
+}: PostFeedSectionProps): JSX.Element => {
+  const navigate = useNavigate();
+
   return (
     <Box>
       <Box
@@ -25,6 +32,9 @@ const PostFeedSection = ({ posts }: PostFeedSectionProps): JSX.Element => {
           size="small"
           variant="text"
           sx={{ color: '#333', fontWeight: 'bold' }}
+          onClick={() => {
+            navigate(`/my-page/${userId}/feeds/posts`);
+          }}
         >
           더보기
         </Button>
@@ -38,8 +48,8 @@ const PostFeedSection = ({ posts }: PostFeedSectionProps): JSX.Element => {
           >
             <PostCard
               title={post.title}
-              content={post.content}
-              author={post.author}
+              description={post.description}
+              userName={post.userName}
               avatar={post.avatar}
             />
           </Grid>

--- a/src/components/MyPage/Feed/ReviewFeedSection.tsx
+++ b/src/components/MyPage/Feed/ReviewFeedSection.tsx
@@ -2,14 +2,19 @@ import ReviewCard from '@components/commons/DetailPageReviewCard';
 import { Box, Typography, Button } from '@mui/material';
 import Grid from '@mui/material/Grid2';
 import { Review } from '@shared/types/type';
+import { useNavigate } from 'react-router-dom';
 
 interface ReviewFeedSectionProps {
+  userId: string;
   reviews: Review[];
 }
 
 const ReviewFeedSection = ({
+  userId,
   reviews,
 }: ReviewFeedSectionProps): JSX.Element => {
+  const navigate = useNavigate();
+
   return (
     <Box sx={{ marginBottom: '2rem' }}>
       <Box
@@ -27,6 +32,9 @@ const ReviewFeedSection = ({
           size="small"
           variant="text"
           sx={{ color: '#333', fontWeight: 'bold' }}
+          onClick={() => {
+            navigate(`/my-page/${userId}/feeds/reviews`);
+          }}
         >
           더보기
         </Button>

--- a/src/components/MyPage/Feed/UserFeedTabPanel.tsx
+++ b/src/components/MyPage/Feed/UserFeedTabPanel.tsx
@@ -12,7 +12,13 @@ const UserFeedTabPanel = ({ userId }: UserFeedTabPanelProps): JSX.Element => {
   if (isLoading) return <Typography>로딩 중...</Typography>;
   if (error) return <Typography>에러 발생: {JSON.stringify(error)}</Typography>;
 
-  return <>{feeds && <Feed posts={feeds.posts} reviews={feeds.reviews} />}</>;
+  return (
+    <>
+      {feeds && (
+        <Feed userId={userId} posts={feeds.posts} reviews={feeds.reviews} />
+      )}
+    </>
+  );
 };
 
 export default UserFeedTabPanel;

--- a/src/components/PostMorePage/PostMoreTemplate.tsx
+++ b/src/components/PostMorePage/PostMoreTemplate.tsx
@@ -1,0 +1,36 @@
+import PostCard from '@components/commons/DetailPagePostCard';
+import InfiniteScrollComponent from '@components/commons/InfiniteScroll';
+import { Box, Typography } from '@mui/material';
+import { Post } from '@shared/types/type';
+
+interface PostMoreTemplateProps {
+  totalPosts?: number;
+  posts: Post[];
+  hasMore: boolean;
+  fetchMoreData: () => void;
+}
+
+const PostMoreTemplate = ({
+  totalPosts,
+  posts,
+  hasMore,
+  fetchMoreData,
+}: PostMoreTemplateProps) => {
+  return (
+    <Box sx={{ padding: '1rem', maxWidth: '1200px', margin: 'auto' }}>
+      <Typography variant="h5" fontWeight="bold" sx={{ marginBottom: '1rem' }}>
+        {`포스트 목록 (${totalPosts || 0}개)`}
+      </Typography>
+
+      <InfiniteScrollComponent
+        items={posts}
+        hasMore={hasMore}
+        fetchMore={fetchMoreData}
+        gridSize={{ xs: 12, md: 6 }}
+        renderItem={(post) => <PostCard {...post} />}
+      />
+    </Box>
+  );
+};
+
+export default PostMoreTemplate;

--- a/src/components/ReviewMorePage/ReviewMorePageTemplate.tsx
+++ b/src/components/ReviewMorePage/ReviewMorePageTemplate.tsx
@@ -1,0 +1,141 @@
+import React, { useEffect, useState } from 'react';
+import { Box, Typography, Stack } from '@mui/material';
+import StarRating from '@components/commons/StarRating';
+import ReviewSortOptions from '@components/ReviewMorePage/ReviewSortOptions';
+import InfiniteScrollComponent from '@components/commons/InfiniteScroll';
+import ReviewCard from '@components/commons/DetailPageReviewCard';
+import OneLineReviewDialog from '@components/FeedPage/OneLineReviewDialog/OneLineReviewDialog';
+import { Book, Review } from '@shared/types/type';
+
+interface BookDetail extends Omit<Book, 'bookTitle'> {
+  title: string;
+}
+
+interface ReviewMorePageTemplateProps {
+  reviews: Review[];
+  hasMore: boolean;
+  fetchMoreData: () => void;
+  bookDetails?: BookDetail;
+}
+
+const ReviewMorePageTemplate: React.FC<ReviewMorePageTemplateProps> = ({
+  reviews,
+  hasMore,
+  fetchMoreData,
+  bookDetails,
+}) => {
+  const [selectedRating, setSelectedRating] = useState<number>(0); // 별점 상태
+  const [isDialogOpen, setIsDialogOpen] = useState<boolean>(false); // 모달 상태
+  const [sortOption, setSortOption] = useState<string>('likes'); // 정렬 상태
+  const [sortedReviews, setSortedReviews] = useState<Review[]>(reviews); // 정렬된 리뷰
+
+  useEffect(() => {
+    const updatedReviews = [...reviews];
+    if (sortOption === 'likes') {
+      updatedReviews.sort((a, b) => b.likes - a.likes);
+    } else if (sortOption === 'ratingHigh') {
+      updatedReviews.sort((a, b) => b.rating - a.rating);
+    } else if (sortOption === 'ratingLow') {
+      updatedReviews.sort((a, b) => a.rating - b.rating);
+    } else if (sortOption === 'latest') {
+      updatedReviews.sort(
+        (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime(),
+      );
+    }
+
+    setSortedReviews(updatedReviews);
+  }, [reviews, sortOption]);
+
+  // 별점 변경 처리
+  const handleRatingChange = (rating: number) => {
+    setSelectedRating(rating);
+    setIsDialogOpen(true);
+  };
+
+  // 모달 닫기 처리
+  const handleModalClose = () => {
+    setIsDialogOpen(false);
+  };
+
+  // 정렬 옵션 변경 처리
+  const handleSortChange = (option: string) => {
+    setSortOption(option);
+  };
+
+  return (
+    <Box
+      sx={{
+        padding: '1rem',
+        maxWidth: '800px',
+        margin: 'auto',
+      }}
+    >
+      {/* StarRating 박스 */}
+      {bookDetails && (
+        <Box
+          sx={{
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            justifyContent: 'center',
+            padding: '1rem',
+            border: '1px solid #e7e8e9',
+            borderRadius: '8px',
+            marginBottom: '1.5rem',
+          }}
+        >
+          <StarRating
+            rating={selectedRating}
+            onRatingChange={handleRatingChange}
+            isDialog={false}
+          />
+          <Typography
+            variant="body2"
+            color="text.secondary"
+            sx={{ marginTop: '0.5rem' }}
+          >
+            이 책은 어떠셨나요? 별점을 남겨주세요
+          </Typography>
+        </Box>
+      )}
+
+      {/* 제목 및 정렬 옵션 */}
+      <Stack direction="row" justifyContent="space-between">
+        <Typography
+          variant="h5"
+          fontWeight="bold"
+          sx={{ marginBottom: '1rem' }}
+        >
+          한 줄 리뷰 {sortedReviews.length}
+        </Typography>
+        <ReviewSortOptions value={sortOption} onChange={handleSortChange} />
+      </Stack>
+
+      {/* 무한 스크롤 */}
+      <InfiniteScrollComponent
+        items={sortedReviews} // 정렬된 리뷰를 전달
+        hasMore={hasMore}
+        fetchMore={fetchMoreData}
+        gridSize={{ xs: 12, md: 12 }}
+        renderItem={(review) => <ReviewCard {...review} />}
+      />
+
+      {/* 한 줄 리뷰 작성 모달 */}
+      {bookDetails && (
+        <OneLineReviewDialog
+          isOpen={isDialogOpen}
+          onClose={handleModalClose}
+          receivedBook={{
+            bookTitle: bookDetails.title,
+            imageUrl: bookDetails.imageUrl,
+            author: bookDetails.author,
+            itemId: bookDetails.itemId,
+          }}
+          receivedRating={selectedRating}
+        />
+      )}
+    </Box>
+  );
+};
+
+export default ReviewMorePageTemplate;

--- a/src/features/MyPage/api/userFeedsApi.ts
+++ b/src/features/MyPage/api/userFeedsApi.ts
@@ -2,6 +2,8 @@ import { Post } from '@components/BookDetailPage/BookReviewTab';
 import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
 import { Review } from '@shared/types/type';
 
+type FeedType = 'review' | 'post';
+
 export const userFeedsApi = createApi({
   reducerPath: 'userFeedsApi',
   baseQuery: fetchBaseQuery({ baseUrl: '/api' }),
@@ -16,6 +18,13 @@ export const userFeedsApi = createApi({
     >({
       query: (userId) => `user/${userId}/feeds`,
     }),
+    getUserPaginatedFeeds: builder.query<
+      { feeds: Post[]; totalFeeds: number },
+      { userId: string; feedType: FeedType; page: number }
+    >({
+      query: ({ userId, feedType, page }) =>
+        `user/${userId}/feeds/${feedType}?page=${page}`,
+    }),
     getLikedFeeds: builder.query<
       {
         reviews: Review[];
@@ -25,7 +34,19 @@ export const userFeedsApi = createApi({
     >({
       query: (userId) => `user/${userId}/feeds/liked`,
     }),
+    getLikedPaginatedFeeds: builder.query<
+      { feeds: Post[]; totalFeeds: number },
+      { userId: string; feedType: FeedType; page: number }
+    >({
+      query: ({ userId, feedType, page }) =>
+        `user/${userId}/feeds/liked/${feedType}?page=${page}`,
+    }),
   }),
 });
 
-export const { useGetUserFeedsQuery, useGetLikedFeedsQuery } = userFeedsApi;
+export const {
+  useGetUserFeedsQuery,
+  useGetUserPaginatedFeedsQuery,
+  useGetLikedFeedsQuery,
+  useGetLikedPaginatedFeedsQuery,
+} = userFeedsApi;

--- a/src/mocks/handlers/user.ts
+++ b/src/mocks/handlers/user.ts
@@ -7,105 +7,298 @@ const mockUser = {
   avatarUrl: 'https://github.com/publdaze.png',
 };
 
+const userPosts = [
+  {
+    itemId: '40869703',
+    title: '추천 도서 소개',
+    description: '제가 좋아하는 책을 소개합니다.',
+    userName: '김구름',
+    avatar: '/path/to/avatar1.jpg',
+    createdAt: '2024-01-01T10:00:00Z',
+  },
+  {
+    itemId: '40869703',
+    title: '독서의 즐거움',
+    description: '독서를 통해 얻는 지식과 행복에 대해 이야기합니다.',
+    userName: '김구름',
+    avatar: '/path/to/avatar2.jpg',
+    createdAt: '2024-01-02T11:00:00Z',
+  },
+  {
+    itemId: '40869703',
+    title: '2024년 독서 계획',
+    description: '올해는 이 책들과 함께 즐거운 독서를 해보려 합니다.',
+    userName: '김구름',
+    avatar: '/path/to/avatar3.jpg',
+    createdAt: '2024-01-03T12:00:00Z',
+  },
+  {
+    itemId: '40869703',
+    title: '책으로 떠나는 여행',
+    description: '책에서 만나는 다양한 세계를 공유합니다.',
+    userName: '김구름',
+    avatar: '/path/to/avatar4.jpg',
+    createdAt: '2023-12-31T15:00:00Z',
+  },
+  {
+    itemId: '40869703',
+    title: '추천 도서 목록',
+    description: '제가 추천하는 도서 목록을 확인해보세요!',
+    userName: '김구름',
+    avatar: '/path/to/avatar5.jpg',
+    createdAt: '2023-12-30T14:00:00Z',
+  },
+  {
+    itemId: '40869703',
+    title: '읽고 싶은 책',
+    description: '다음에 꼭 읽고 싶은 책들을 소개합니다.',
+    userName: '김구름',
+    avatar: '/path/to/avatar6.jpg',
+    createdAt: '2023-12-29T13:00:00Z',
+  },
+  {
+    itemId: '40869703',
+    title: '고전 문학의 매력',
+    description: '고전 문학을 통해 느낄 수 있는 감동을 전합니다.',
+    userName: '김구름',
+    avatar: '/path/to/avatar7.jpg',
+    createdAt: '2023-12-28T16:00:00Z',
+  },
+  {
+    itemId: '40869703',
+    title: '독서 방법 공유',
+    description: '효율적으로 책을 읽는 방법을 공유합니다.',
+    userName: '김구름',
+    avatar: '/path/to/avatar8.jpg',
+    createdAt: '2023-12-27T17:00:00Z',
+  },
+  {
+    itemId: '40869703',
+    title: '독서 기록',
+    description: '제가 읽은 책에 대한 기록을 남깁니다.',
+    userName: '김구름',
+    avatar: '/path/to/avatar9.jpg',
+    createdAt: '2023-12-26T18:00:00Z',
+  },
+  {
+    itemId: '40869703',
+    title: '새로운 책 소개',
+    description: '최근에 구매한 책을 소개합니다.',
+    userName: '김구름',
+    avatar: '/path/to/avatar10.jpg',
+    createdAt: '2023-12-25T19:00:00Z',
+  },
+  {
+    itemId: '278770576',
+    title: '새로운 책 소개',
+    description: '최근에 구매한 책을 소개합니다.',
+    userName: '김구름',
+    avatar: '/path/to/avatar10.jpg',
+    createdAt: '2023-12-25T19:00:00Z',
+  },
+  {
+    itemId: '278770576',
+    title: '새로운 책 소개',
+    description: '최근에 구매한 책을 소개합니다.',
+    userName: '김구름',
+    avatar: '/path/to/avatar10.jpg',
+    createdAt: '2023-12-25T19:00:00Z',
+  },
+];
+
+const userReviews = [
+  {
+    username: '김독서',
+    date: '2024.08.01',
+    content: '새롭네요!',
+    likes: 1,
+    rating: 4, // 별점 추가
+  },
+  {
+    username: '김독서',
+    date: '2024.02.27',
+    content: '도슨트북 새롭고 재미있어요',
+    likes: 1,
+    rating: 5, // 별점 추가
+  },
+  {
+    username: '김독서',
+    date: '2024.10.16',
+    content: '책에 더 흥미를 갖게 도와주는 것 같아요',
+    likes: 1,
+    rating: 3, // 별점 추가
+  },
+];
+
+const likedPosts = [
+  {
+    itemId: '40869703',
+    title: '추천 도서 소개',
+    description: '제가 좋아하는 책을 소개합니다.',
+    userName: '독서연구소',
+    avatar: '/path/to/avatar1.jpg',
+    createdAt: '2024-01-01T10:00:00Z',
+  },
+  {
+    itemId: '40869703',
+    title: '독서의 즐거움',
+    description: '독서를 통해 얻는 지식과 행복에 대해 이야기합니다.',
+    userName: '책사랑',
+    avatar: '/path/to/avatar2.jpg',
+    createdAt: '2024-01-02T11:00:00Z',
+  },
+  {
+    itemId: '40869703',
+    title: '2024년 독서 계획',
+    description: '올해는 이 책들과 함께 즐거운 독서를 해보려 합니다.',
+    userName: '책벌레',
+    avatar: '/path/to/avatar3.jpg',
+    createdAt: '2024-01-03T12:00:00Z',
+  },
+  {
+    itemId: '40869703',
+    title: '책으로 떠나는 여행',
+    description: '책에서 만나는 다양한 세계를 공유합니다.',
+    userName: '책여행자',
+    avatar: '/path/to/avatar4.jpg',
+    createdAt: '2023-12-31T15:00:00Z',
+  },
+  {
+    itemId: '40869703',
+    title: '추천 도서 목록',
+    description: '제가 추천하는 도서 목록을 확인해보세요!',
+    userName: '추천왕',
+    avatar: '/path/to/avatar5.jpg',
+    createdAt: '2023-12-30T14:00:00Z',
+  },
+  {
+    itemId: '40869703',
+    title: '읽고 싶은 책',
+    description: '다음에 꼭 읽고 싶은 책들을 소개합니다.',
+    userName: '책수집가',
+    avatar: '/path/to/avatar6.jpg',
+    createdAt: '2023-12-29T13:00:00Z',
+  },
+  {
+    itemId: '40869703',
+    title: '고전 문학의 매력',
+    description: '고전 문학을 통해 느낄 수 있는 감동을 전합니다.',
+    userName: '문학연구소',
+    avatar: '/path/to/avatar7.jpg',
+    createdAt: '2023-12-28T16:00:00Z',
+  },
+  {
+    itemId: '40869703',
+    title: '독서 방법 공유',
+    description: '효율적으로 책을 읽는 방법을 공유합니다.',
+    userName: '효율적독서',
+    avatar: '/path/to/avatar8.jpg',
+    createdAt: '2023-12-27T17:00:00Z',
+  },
+  {
+    itemId: '40869703',
+    title: '독서 기록',
+    description: '제가 읽은 책에 대한 기록을 남깁니다.',
+    userName: '기록자',
+    avatar: '/path/to/avatar9.jpg',
+    createdAt: '2023-12-26T18:00:00Z',
+  },
+  {
+    itemId: '40869703',
+    title: '새로운 책 소개',
+    description: '최근에 구매한 책을 소개합니다.',
+    userName: '새책사랑',
+    avatar: '/path/to/avatar10.jpg',
+    createdAt: '2023-12-25T19:00:00Z',
+  },
+  {
+    itemId: '278770576',
+    title: '새로운 책 소개',
+    description: '최근에 구매한 책을 소개합니다.',
+    userName: '새책사랑',
+    avatar: '/path/to/avatar10.jpg',
+    createdAt: '2023-12-25T19:00:00Z',
+  },
+  {
+    itemId: '278770576',
+    title: '새로운 책 소개',
+    description: '최근에 구매한 책을 소개합니다.',
+    userName: '새책사랑',
+    avatar: '/path/to/avatar10.jpg',
+    createdAt: '2023-12-25T19:00:00Z',
+  },
+];
+
+const likedReviews = [
+  {
+    username: 'Lovely ChaeChae',
+    date: '2024.08.01',
+    content: '새롭네요!',
+    likes: 1,
+    rating: 4, // 별점 추가
+  },
+  {
+    username: '독서왕난이',
+    date: '2024.02.27',
+    content: '도슨트북 새롭고 재미있어요',
+    likes: 1,
+    rating: 5, // 별점 추가
+  },
+  {
+    username: '다비다나고양이',
+    date: '2024.10.16',
+    content: '책에 더 흥미를 갖게 도와주는 것 같아요',
+    likes: 1,
+    rating: 3, // 별점 추가
+  },
+];
+
 export const userHandlers = [
   http.get(`/api/user/:userId/feeds`, () => {
     return HttpResponse.json({
-      posts: [
-        {
-          title: '2월은 결심하기 좋은 자기계발의 달!',
-          content:
-            '2024년에도 어김없이 결심의 시즌이 돌아왔습니다! 여러분을 위한 특별한 추천 도서를 소개합니다.',
-          author: mockUser.name,
-          avatar: '/path/to/avatar1.jpg',
-        },
-        {
-          title: '✨ 2024 상반기 결산 - 책복/도슨트북',
-          content:
-            '밀리에서 전자책 외에다양한 독서 콘텐츠를 빼놓을 수 없죠! 😉밀리는 회원들의 일상생활에 독서가 1밀리 더스며들 수 있도록 다양한 도전을 이어가고 있어요. 챗북부터 도슨트북, 오브제북, 영상 콘텐츠까지!2024년 상반기에도 책을 쉽고, 재밌고, 풍성하게접할 수 있는 새로운 콘텐츠들이 쏟아졌는데요.과연 그중 어떤 콘텐츠가 주목받았는지함께 확인해 볼까요? 2024년의 상반기, 밀리 회원들이 좋아한 콘텐츠 랭킹을 보면 인간관계에 대한 관심이 높아진 것',
-          author: mockUser.name,
-          avatar: '/path/to/avatar1.jpg',
-        },
-        {
-          title: '좋아하는 것들',
-          content: '나만의 취향을 담은 독서 추천, 여러분과 함께 하고 싶어요.',
-          author: mockUser.name,
-          avatar: '/path/to/avatar1.jpg',
-        },
-      ],
-      reviews: [
-        {
-          username: mockUser.name,
-          date: '2024.08.01',
-          content: '새롭네요!',
-          likes: 1,
-          rating: 4, // 별점 추가
-        },
-        {
-          username: mockUser.name,
-          date: '2024.02.27',
-          content: '도슨트북 새롭고 재미있어요',
-          likes: 1,
-          rating: 5, // 별점 추가
-        },
-        {
-          username: mockUser.name,
-          date: '2024.10.16',
-          content: '책에 더 흥미를 갖게 도와주는 것 같아요',
-          likes: 1,
-          rating: 3, // 별점 추가
-        },
-      ],
+      posts: userPosts.slice(0, 3),
+      reviews: userReviews,
     });
   }),
   http.get(`/api/user/:userId/feeds/liked`, () => {
     return HttpResponse.json({
-      posts: [
-        {
-          title: '2월은 결심하기 좋은 자기계발의 달!',
-          content:
-            '2024년에도 어김없이 결심의 시즌이 돌아왔습니다! 여러분을 위한 특별한 추천 도서를 소개합니다.',
-          author: 'MILLIE 밀리',
-          avatar: '/path/to/avatar1.jpg',
-        },
-        {
-          title: '✨ 2024 상반기 결산 - 책복/도슨트북',
-          content:
-            '밀리에서 전자책 외에다양한 독서 콘텐츠를 빼놓을 수 없죠! 😉밀리는 회원들의 일상생활에 독서가 1밀리 더스며들 수 있도록 다양한 도전을 이어가고 있어요. 챗북부터 도슨트북, 오브제북, 영상 콘텐츠까지!2024년 상반기에도 책을 쉽고, 재밌고, 풍성하게접할 수 있는 새로운 콘텐츠들이 쏟아졌는데요.과연 그중 어떤 콘텐츠가 주목받았는지함께 확인해 볼까요? 2024년의 상반기, 밀리 회원들이 좋아한 콘텐츠 랭킹을 보면 인간관계에 대한 관심이 높아진 것',
-          author: '밀리 독서연구소',
-          avatar: '/path/to/avatar2.jpg',
-        },
-        {
-          title: '좋아하는 것들',
-          content: '나만의 취향을 담은 독서 추천, 여러분과 함께 하고 싶어요.',
-          author: '16층 노예',
-          avatar: '/path/to/avatar3.jpg',
-        },
-      ],
-      reviews: [
-        {
-          username: 'Lovely ChaeChae',
-          date: '2024.08.01',
-          content: '새롭네요!',
-          likes: 1,
-          rating: 4, // 별점 추가
-        },
-        {
-          username: '독서왕난이',
-          date: '2024.02.27',
-          content: '도슨트북 새롭고 재미있어요',
-          likes: 1,
-          rating: 5, // 별점 추가
-        },
-        {
-          username: '다비다나고양이',
-          date: '2024.10.16',
-          content: '책에 더 흥미를 갖게 도와주는 것 같아요',
-          likes: 1,
-          rating: 3, // 별점 추가
-        },
-      ],
+      posts: likedPosts.slice(0, 3),
+      reviews: likedReviews,
     });
   }),
+  http.get('/api/user/:userId/feeds/:feedType', ({ params, request }) => {
+    const { feedType } = params;
+    const url = new URL(request.url); // 문자열 URL을 URL 객체로 변환
+    const page = parseInt(url.searchParams.get('page') || '1', 10);
+    const limit = 5; // 한 페이지당 리뷰 수
+
+    const selectedFeed = feedType === 'post' ? userPosts : userReviews;
+    const totalFeeds = selectedFeed.length;
+    const startIndex = (page - 1) * limit;
+    const paginatedFeeds = selectedFeed.slice(startIndex, startIndex + limit);
+
+    return HttpResponse.json(
+      { feeds: paginatedFeeds, totalFeeds },
+      { status: 200 },
+    );
+  }),
+  http.get('/api/user/:userId/feeds/liked/:feedType', ({ params, request }) => {
+    const { feedType } = params;
+    const url = new URL(request.url); // 문자열 URL을 URL 객체로 변환
+    const page = parseInt(url.searchParams.get('page') || '1', 10);
+    const limit = 5; // 한 페이지당 리뷰 수
+
+    const selectedFeed = feedType === 'post' ? likedPosts : likedReviews;
+    const totalFeeds = selectedFeed.length;
+    const startIndex = (page - 1) * limit;
+    const paginatedFeeds = selectedFeed.slice(startIndex, startIndex + limit);
+
+    return HttpResponse.json(
+      { feeds: paginatedFeeds, totalFeeds },
+      { status: 200 },
+    );
+  }),
+
   http.post('/api/user/:userId/password-check', async ({ request }) => {
     const { password } = (await request.json()) as { password: string };
 

--- a/src/pages/LikedPostMorePage/LikedPostMorePage.tsx
+++ b/src/pages/LikedPostMorePage/LikedPostMorePage.tsx
@@ -1,0 +1,40 @@
+import { useState, useEffect } from 'react';
+import { Post } from '@shared/types/type';
+import PostMoreTemplate from '@components/PostMorePage/PostMoreTemplate';
+import { useGetLikedPaginatedFeedsQuery } from '@features/MyPage/api/userFeedsApi';
+
+const LikedPostMorePage = (): JSX.Element => {
+  const [posts, setPosts] = useState<Post[]>([]);
+  const [page, setPage] = useState(1);
+  const [hasMore, setHasMore] = useState(true);
+
+  const { data, isLoading, isError } = useGetLikedPaginatedFeedsQuery({
+    userId: 'user',
+    feedType: 'post',
+    page,
+  });
+
+  useEffect(() => {
+    if (data?.feeds) {
+      setPosts((prevPosts) => [...prevPosts, ...data.feeds]);
+      if (data.feeds.length < 10) setHasMore(false);
+    }
+  }, [data]);
+
+  const fetchMoreData = () => {
+    if (!isLoading && !isError) {
+      setPage((prevPage) => prevPage + 1);
+    }
+  };
+
+  return (
+    <PostMoreTemplate
+      totalPosts={data?.totalFeeds}
+      posts={posts}
+      hasMore={hasMore}
+      fetchMoreData={fetchMoreData}
+    />
+  );
+};
+
+export default LikedPostMorePage;

--- a/src/pages/LikedReviewMorePage/LikedReviewMorePage.tsx
+++ b/src/pages/LikedReviewMorePage/LikedReviewMorePage.tsx
@@ -1,0 +1,39 @@
+import { useState, useEffect } from 'react';
+import { Review } from '@shared/types/type';
+import ReviewMorePageTemplate from '@components/ReviewMorePage/ReviewMorePageTemplate';
+import { useGetLikedPaginatedFeedsQuery } from '@features/MyPage/api/userFeedsApi';
+
+const LikedReviewMorePage = (): JSX.Element => {
+  const [reviews, setReviews] = useState<Review[]>([]); // 가져온 리뷰 데이터
+  const [page, setPage] = useState(1); // 현재 페이지
+  const [hasMore, setHasMore] = useState(true); // 추가 데이터 여부
+
+  const { data, isLoading, isError } = useGetLikedPaginatedFeedsQuery({
+    userId: 'user',
+    feedType: 'review',
+    page,
+  });
+
+  useEffect(() => {
+    if (data?.feeds) {
+      setReviews((prevReviews) => [...prevReviews, ...data.feeds]);
+      if (data.feeds.length < 5) setHasMore(false);
+    }
+  }, [data]);
+
+  const fetchMoreData = () => {
+    if (!isLoading && !isError) {
+      setPage((prevPage) => prevPage + 1);
+    }
+  };
+
+  return (
+    <ReviewMorePageTemplate
+      reviews={reviews}
+      hasMore={hasMore}
+      fetchMoreData={fetchMoreData}
+    />
+  );
+};
+
+export default LikedReviewMorePage;

--- a/src/pages/PostMorePage/PostMorePage.tsx
+++ b/src/pages/PostMorePage/PostMorePage.tsx
@@ -1,10 +1,8 @@
-import { Box, Typography } from '@mui/material';
-import InfiniteScrollComponent from '@components/commons/InfiniteScroll';
-import PostCard from '@components/commons/DetailPagePostCard';
 import { useState, useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
 import { useGetPaginatedPostsQuery } from '@features/BookDetailPage/api/postApi';
 import { BookDetailPost } from '@shared/types/type';
+import PostMoreTemplate from '@components/PostMorePage/PostMoreTemplate';
 
 const PostMorePage = (): JSX.Element => {
   const location = useLocation();
@@ -34,19 +32,12 @@ const PostMorePage = (): JSX.Element => {
   };
 
   return (
-    <Box sx={{ padding: '1rem', maxWidth: '1200px', margin: 'auto' }}>
-      <Typography variant="h5" fontWeight="bold" sx={{ marginBottom: '1rem' }}>
-        {`포스트 목록 (${data?.totalPosts || 0}개)`}
-      </Typography>
-
-      <InfiniteScrollComponent
-        items={posts}
-        hasMore={hasMore}
-        fetchMore={fetchMoreData}
-        gridSize={{ xs: 12, md: 6 }}
-        renderItem={(post) => <PostCard {...post} />}
-      />
-    </Box>
+    <PostMoreTemplate
+      totalPosts={data?.totalPosts}
+      posts={posts}
+      hasMore={hasMore}
+      fetchMoreData={fetchMoreData}
+    />
   );
 };
 

--- a/src/pages/ReviewMorePage/ReviewMorePage.tsx
+++ b/src/pages/ReviewMorePage/ReviewMorePage.tsx
@@ -1,13 +1,8 @@
-import { Box, Typography, Stack } from '@mui/material';
-import InfiniteScrollComponent from '@components/commons/InfiniteScroll';
-import ReviewCard from '@components/commons/DetailPageReviewCard';
 import { useState, useEffect } from 'react';
-import ReviewSortOptions from '@components/ReviewMorePage/ReviewSortOptions';
-import StarRating from '@components/commons/StarRating';
-import OneLineReviewDialog from '@components/FeedPage/OneLineReviewDialog/OneLineReviewDialog';
 import { useLocation } from 'react-router-dom';
 import { useGetPaginatedReviewsQuery } from '@features/BookDetailPage/api/reviewApi';
 import { Review } from '@shared/types/type';
+import ReviewMorePageTemplate from '@components/ReviewMorePage/ReviewMorePageTemplate';
 
 const ReviewMorePage = (): JSX.Element => {
   const location = useLocation();
@@ -17,9 +12,6 @@ const ReviewMorePage = (): JSX.Element => {
   const [reviews, setReviews] = useState<Review[]>([]); // 가져온 리뷰 데이터
   const [page, setPage] = useState(1); // 현재 페이지
   const [hasMore, setHasMore] = useState(true); // 추가 데이터 여부
-  const [sortOption, setSortOption] = useState('likes'); // 정렬 옵션
-  const [selectedRating, setSelectedRating] = useState<number>(0); // 별점 상태
-  const [isDialogOpen, setIsDialogOpen] = useState<boolean>(false); // 모달 상태
 
   // 페이지네이션 데이터 가져오기
   const { data, isLoading, isError } = useGetPaginatedReviewsQuery({
@@ -46,108 +38,18 @@ const ReviewMorePage = (): JSX.Element => {
     }
   };
 
-  // 정렬 옵션 변경 처리
-  const handleSortChange = (option: string) => {
-    setSortOption(option);
-
-    // 정렬 로직 적용
-    setReviews((prevReviews) => {
-      const sortedReviews = [...prevReviews];
-      if (option === 'likes') {
-        sortedReviews.sort((a, b) => b.likes - a.likes);
-      } else if (option === 'ratingHigh') {
-        sortedReviews.sort((a, b) => b.rating - a.rating);
-      } else if (option === 'ratingLow') {
-        sortedReviews.sort((a, b) => a.rating - b.rating);
-      } else if (option === 'latest') {
-        sortedReviews.sort(
-          (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime(),
-        );
-      }
-      return sortedReviews;
-    });
-  };
-
-  // 별점 변경 처리
-  const handleRatingChange = (rating: number) => {
-    setSelectedRating(rating);
-    setIsDialogOpen(true); // 별점 클릭 시 모달 열기
-  };
-
-  // 모달 닫기 처리
-  const handleModalClose = () => {
-    setIsDialogOpen(false); // 모달 닫기
-  };
-
   return (
-    <Box
-      sx={{
-        padding: '1rem',
-        maxWidth: '800px',
-        margin: 'auto',
+    <ReviewMorePageTemplate
+      reviews={reviews}
+      hasMore={hasMore}
+      fetchMoreData={fetchMoreData}
+      bookDetails={{
+        title,
+        imageUrl,
+        author,
+        itemId,
       }}
-    >
-      {/* StarRating 박스 */}
-      <Box
-        sx={{
-          display: 'flex',
-          flexDirection: 'column',
-          alignItems: 'center',
-          justifyContent: 'center',
-          padding: '1rem',
-          border: '1px solid #e7e8e9',
-          borderRadius: '8px',
-          marginBottom: '1.5rem',
-        }}
-      >
-        <StarRating
-          rating={selectedRating}
-          onRatingChange={handleRatingChange}
-          isDialog={false}
-        />
-        <Typography
-          variant="body2"
-          color="text.secondary"
-          sx={{ marginTop: '0.5rem' }}
-        >
-          이 책은 어떠셨나요? 별점을 남겨주세요
-        </Typography>
-      </Box>
-
-      {/* 제목 및 정렬 옵션 */}
-      <Stack direction="row" justifyContent="space-between">
-        <Typography
-          variant="h5"
-          fontWeight="bold"
-          sx={{ marginBottom: '1rem' }}
-        >
-          한 줄 리뷰 {reviews.length}
-        </Typography>
-        <ReviewSortOptions value={sortOption} onChange={handleSortChange} />
-      </Stack>
-
-      {/* 무한 스크롤 */}
-      <InfiniteScrollComponent
-        items={reviews}
-        hasMore={hasMore}
-        fetchMore={fetchMoreData}
-        gridSize={{ xs: 12, md: 12 }}
-        renderItem={(review) => <ReviewCard {...review} />}
-      />
-
-      {/* 한 줄 리뷰 작성 모달 */}
-      <OneLineReviewDialog
-        isOpen={isDialogOpen}
-        onClose={handleModalClose}
-        receivedBook={{
-          bookTitle: title!,
-          imageUrl: imageUrl!,
-          author: author!,
-          itemId: itemId!,
-        }}
-        receivedRating={selectedRating}
-      />
-    </Box>
+    />
   );
 };
 

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -15,7 +15,8 @@ import EditAccountPage from '@pages/EditAccountPage.tsx/EditAccountPage';
 import PasswordChkPage from '@pages/PasswordChkPage/PasswordChkPage';
 import KakaoCallback from '@features/SNSLogin/auth/KakaoCallback';
 import PostingWritePage from '@pages/PostingWritePage/PostingWritePage';
-
+import LikedPostMorePage from '@pages/LikedPostMorePage/LikedPostMorePage';
+import LikedReviewMorePage from '@pages/LikedReviewMorePage/LikedReviewMorePage';
 const AppRouter = () => {
   return (
     <Routes>
@@ -54,6 +55,14 @@ const AppRouter = () => {
       <Route
         path={`${RoutePaths.POSTING}/:postingId?`}
         element={<PostingDetailPage />}
+      />
+      <Route
+        path={`${RoutePaths.MY_PAGE}/:userId?/feeds/${RoutePaths.POSTS}`}
+        element={<LikedPostMorePage />}
+      />
+      <Route
+        path={`${RoutePaths.MY_PAGE}/:userId?/feeds/${RoutePaths.REVIEWS}`}
+        element={<LikedReviewMorePage />}
       />
       <Route path="*" element={<NotFoundPage />} />
     </Routes>


### PR DESCRIPTION
## 연관 이슈

- #117

## 작업 요약

- 피드 탭 더보기 페이지

## 작업 상세 설명

- 책 상세 페이지에서 사용되는 더보기 페이지 UI 분리해주고, 피드 탭 더보기 페이지 새로 생성하여 구현하였습니다.

## 리뷰 요구사항

- 15분?
- 머리가 안 돌아가서, 놓친 부분이 좀 있을 수도 있을 것 같은데, 일단 PR 더 늦어지면 안 될 것 같아서 먼저 올리고, 추후 다시 검토해보고 새 이슈 파서 부족한 부분 보완하겠습니다.

## Preview 이미지

https://github.com/user-attachments/assets/93472ad8-cfde-408e-bf8d-8c80ca9a32bf

