### PR TITLE
운영서버 api 동작 안 하는 문제 해결

### DIFF
--- a/src/features/BookSearchPage/api/bestBookGetApi.ts
+++ b/src/features/BookSearchPage/api/bestBookGetApi.ts
@@ -5,7 +5,7 @@ import { BestBookResponse } from '@features/BookSearchPage/types/types';
 export const bestBookGetApi = createApi({
   reducerPath: 'bestBookGetApi',
   baseQuery: fetchBaseQuery({
-    baseUrl: '/api', // Vite 프록시가 중계
+    baseUrl: aladinConfig.aladinBaseUrl,
   }),
   endpoints: (builder) => ({
     getBestBooks: builder.query<BestBookResponse, void>({

--- a/src/features/BookSearchPage/api/bookDetailApi.ts
+++ b/src/features/BookSearchPage/api/bookDetailApi.ts
@@ -4,7 +4,7 @@ import { BookDetailResponse } from '@features/BookSearchPage/types/types';
 
 export const bookDetailApi = createApi({
   reducerPath: 'bookDetailApi',
-  baseQuery: fetchBaseQuery({ baseUrl: '/api' }),
+  baseQuery: fetchBaseQuery({ baseUrl: aladinConfig.aladinBaseUrl }),
   endpoints: (builder) => ({
     fetchBookDetail: builder.query<BookDetailResponse, { itemId: number }>({
       query: ({ itemId }) => ({

--- a/src/features/BookSearchPage/api/bookSearchApi.ts
+++ b/src/features/BookSearchPage/api/bookSearchApi.ts
@@ -9,7 +9,7 @@ import {
 export const bookSearchApi = createApi({
   reducerPath: 'bookSearchApi',
   baseQuery: fetchBaseQuery({
-    baseUrl: '/api',
+    baseUrl: aladinConfig.aladinBaseUrl,
   }),
   endpoints: (builder) => ({
     searchBooks: builder.query<BookResponse, SearchBooksParams>({

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,9 +6,9 @@ import { muiTheme } from '@styles/theme.ts';
 import { ThemeProvider } from '@mui/material';
 
 async function enableMocking() {
-  if (process.env.NODE_ENV !== 'development') {
-    return;
-  }
+  // if (process.env.NODE_ENV !== 'development') {
+  //   return;
+  // }
 
   const { worker } = await import('./mocks/browser');
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,23 +1,5 @@
-import { defineConfig, loadEnv } from 'vite';
+import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import tsconfigPaths from 'vite-tsconfig-paths';
 
-export default defineConfig(({ mode }) => {
-  const env = loadEnv(mode, process.cwd()); // 이 줄 추가
-
-  return {
-    plugins: [react(), tsconfigPaths()],
-    server: {
-      proxy: {
-        '/api': {
-          target: env.VITE_ALADIN_BASEURL,
-          changeOrigin: true,
-          rewrite: (path) => path.replace(/^\/api/, ''),
-        },
-      },
-    },
-  };
-});
-
-// import.meta.env는 클라이언트 코드에서만 사용 가능하고,
-// vite.config.ts에서는 loadEnv를 사용해야 합니다.
+export default defineConfig({ plugins: [react(), tsconfigPaths()] });


### PR DESCRIPTION
## 연관 이슈

- Close #138

## 작업 요약

- 운영서버에서 알라딘 api 호출 문제, msw로 인한 api 호출 문제 해결하였습니다.

## 작업 상세 설명

- [프록시 서버 설정](https://vite.dev/config/server-options.html#server-proxy)이 개발 서버 대상이라서 운영 서버에서 동작 안 되는 문제를 해결하였습니다.
  - s3에서 프록시 서버 구축하려면 별도의 프록시 서버 구축이 필요해보여서 프록시 서버없이 redux toolkit baseurl 설정을 통해 알라딘 api 호출 경로 직접 지정해주었습니다.
- msw 목업 서버 저희는 운영서버에서도 사용하는데, 개발서버에서만 동작되도록 구현되어 있어서 해당 부분 주석 처리해두었습니다.
  - 혹시나 나중에 supabase로나 api 구현하게 될 가능성도 고려하여, 삭제 안 하고 일단 주석으로만 처리해두었습니다.

## 리뷰 요구사항

- 5분

## Preview 이미지

### 로컬 서버에서 정상 동작합니다.
<img width="1278" alt="스크린샷 2025-01-09 오후 5 18 26" src="https://github.com/user-attachments/assets/85a01356-bb98-4db8-8ca4-e5adeae5eda1" />

### 운영 서버에서 정상 동작합니다.
<img width="1281" alt="image" src="https://github.com/user-attachments/assets/b97296a5-e211-43c5-9fb7-b2b703e40f26" />
