### PR TITLE
타입정리 & 오류 수정

### DIFF
--- a/src/components/BookShelvesPage/SortSelector.tsx
+++ b/src/components/BookShelvesPage/SortSelector.tsx
@@ -6,7 +6,7 @@ import {
   // Typography,
 } from '@mui/material';
 import { bookShelvesStyles } from './BookShelves.styles';
-import { SortOption } from './types';
+import { SortOption } from '@features/BookShelvesPage/types/types';
 
 interface SortSelectorProps {
   sortOption: SortOption;

--- a/src/components/MyPage/Feed/Feed.tsx
+++ b/src/components/MyPage/Feed/Feed.tsx
@@ -1,6 +1,4 @@
-import { Review } from '@shared/types/type';
-/* TODO - Post interface 통합 후 @shared/types/type Post로 변경 필요 */
-import { Post } from '@components/BookDetailPage/BookReviewTab';
+import { Review, Post } from '@shared/types/type';
 import ReviewFeedSection from './ReviewFeedSection';
 import PostFeedSection from './PostFeedSection';
 

--- a/src/components/MyPage/Feed/PostFeedSection.tsx
+++ b/src/components/MyPage/Feed/PostFeedSection.tsx
@@ -1,4 +1,4 @@
-import { Post } from '@components/BookDetailPage/BookReviewTab';
+import { Post } from '@shared/types/type';
 import PostCard from '@components/commons/DetailPagePostCard';
 import { Box, Typography, Button } from '@mui/material';
 import Grid from '@mui/material/Grid2';

--- a/src/components/PostMorePage/PostMoreTemplate.tsx
+++ b/src/components/PostMorePage/PostMoreTemplate.tsx
@@ -1,11 +1,11 @@
 import PostCard from '@components/commons/DetailPagePostCard';
 import InfiniteScrollComponent from '@components/commons/InfiniteScroll';
 import { Box, Typography } from '@mui/material';
-import { Post } from '@shared/types/type';
+import { BookDetailPost } from '@shared/types/type';
 
 interface PostMoreTemplateProps {
   totalPosts?: number;
-  posts: Post[];
+  posts: BookDetailPost[];
   hasMore: boolean;
   fetchMoreData: () => void;
 }

--- a/src/components/PostingDetailPage/OtherPostingGrid.tsx
+++ b/src/components/PostingDetailPage/OtherPostingGrid.tsx
@@ -2,7 +2,7 @@ import { Box, Typography } from '@mui/material';
 import Grid from '@mui/material/Grid2';
 import OtherPostingCard from './OtherPostingCard';
 import { OtherPost } from '@features/PostDetailPage/types/types';
-import { postingDetailStyles } from './postingDetail.styles';
+import { postingDetailStyles } from '@components/PostingDetailPage/PostingDetail.styles';
 
 interface OtherPostingGridProps {
   title: string;

--- a/src/components/PostingDetailPage/PostingContent.tsx
+++ b/src/components/PostingDetailPage/PostingContent.tsx
@@ -4,7 +4,7 @@ import CommonBookCard from '@components/commons/CommonBookCard';
 import { useNavigate } from 'react-router-dom';
 import { navigateToBookDetailPage } from '@shared/utils/navigation';
 import { Book } from '@shared/types/type';
-import { postingDetailStyles } from './postingDetail.styles';
+import { postingDetailStyles } from '@components/PostingDetailPage/PostingDetail.styles';
 
 interface PostingContentProps {
   content: string;

--- a/src/components/PostingDetailPage/PostingHeader.tsx
+++ b/src/components/PostingDetailPage/PostingHeader.tsx
@@ -7,7 +7,7 @@ import EditIcon from '@mui/icons-material/Edit';
 import { formatCount } from '@shared/utils/formatCount';
 import { useToggleLikeMutation } from '@features/PostDetailPage/api/postingApi';
 import { useNavigate } from 'react-router-dom';
-import { postingDetailStyles } from './postingDetail.styles';
+import { postingDetailStyles } from '@components/PostingDetailPage/PostingDetail.styles';
 
 interface PostingHeaderProps {
   title: string;

--- a/src/components/PostingDetailPage/PostingUserInfo.tsx
+++ b/src/components/PostingDetailPage/PostingUserInfo.tsx
@@ -5,7 +5,7 @@ import {
 import { Box, Typography, Avatar, Button, Stack } from '@mui/material';
 import { User } from '@shared/types/type';
 import { useParams } from 'react-router-dom';
-import { postingDetailStyles } from './PostingDetail.styles';
+import { postingDetailStyles } from '@components/PostingDetailPage/PostingDetail.styles';
 
 interface PostingUserInfoProps {
   user: User;

--- a/src/components/Snackbar/SnackBar.tsx
+++ b/src/components/Snackbar/SnackBar.tsx
@@ -2,7 +2,7 @@ import ReactDOM from 'react-dom';
 import { Snackbar as MuiSnackbar, Alert } from '@mui/material';
 import { useDispatch, useSelector } from 'react-redux';
 import { hideSnackbar } from '@features/Snackbar/snackbarSlice';
-import { RootState } from '@store/store';
+import { RootState } from '@store/index';
 
 const SnackBar = (): JSX.Element | null => {
   const dispatch = useDispatch();

--- a/src/components/commons/BookSearchAutoComplete.tsx
+++ b/src/components/commons/BookSearchAutoComplete.tsx
@@ -50,7 +50,10 @@ const BookSearchAutoComplete = ({
         setAllItems(searchResults.item);
         setPage(2);
       } else {
-        setAllItems((prev) => [...prev, ...searchResults.item]);
+        setAllItems((prev: BookResponse['item']) => [
+          ...prev,
+          ...searchResults.item,
+        ]);
       }
     }
     // 의존성 배열 경고 메시지 무시

--- a/src/features/BookSearchPage/api/bookSearchApi.ts
+++ b/src/features/BookSearchPage/api/bookSearchApi.ts
@@ -6,6 +6,8 @@ import {
   RatingInfoResponse,
 } from '@features/BookSearchPage/types/types';
 
+export type { BookResponse };
+
 export const bookSearchApi = createApi({
   reducerPath: 'bookSearchApi',
   baseQuery: fetchBaseQuery({

--- a/src/features/BookShelvesPage/slice/bookShelvesSlice.ts
+++ b/src/features/BookShelvesPage/slice/bookShelvesSlice.ts
@@ -1,6 +1,6 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
-import { ViewMode } from '@components/BookShelvesPage/ViewToggle';
-import { SortOption } from '@components/BookShelvesPage/SortSelector';
+import { ViewMode } from '@components/BookShelvesPage/types';
+import { SortOption } from '@components/BookShelvesPage/types';
 import { BookshelvesState } from '../types/types';
 
 const initialState: BookshelvesState = {

--- a/src/features/BookShelvesPage/types/types.ts
+++ b/src/features/BookShelvesPage/types/types.ts
@@ -1,6 +1,7 @@
-import { SortOption } from '@components/BookShelvesPage/SortSelector';
-import { ViewMode } from '@components/BookShelvesPage/ViewToggle';
 import { ReadingStatusType, SavedBook } from '@shared/types/type';
+
+export type SortOption = 'recent' | 'title' | 'author';
+export type ViewMode = 'grid' | 'list';
 
 export interface BookInfo {
   itemId: number;

--- a/src/features/MyPage/api/userFeedsApi.ts
+++ b/src/features/MyPage/api/userFeedsApi.ts
@@ -1,4 +1,4 @@
-import { Post } from '@components/BookDetailPage/BookReviewTab';
+import { Post } from '@shared/types/type';
 import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
 import { Review } from '@shared/types/type';
 

--- a/src/mocks/handlers/feed.ts
+++ b/src/mocks/handlers/feed.ts
@@ -109,6 +109,11 @@ const generateMockPosts = (): (OneLinePost | Posting)[] => {
       },
       likeCount: Math.floor(Math.random() * 1000),
       isLiked: false,
+      postType: '선택안함',
+      title: '',
+      description: '',
+      userName: `user${userId}`,
+      avatar: `https://mui.com/static/images/avatar/${Math.floor(Math.random() * 3) + 1}.jpg`,
     };
 
     if (Math.random() < 0.5) {
@@ -241,6 +246,10 @@ export const feedHandlers = [
       isLiked: false,
       review,
       rating,
+      title: `${book.bookTitle} 한줄평`,
+      description: review.substring(0, 50),
+      userName: 'currentUser',
+      avatar: 'https://mui.com/static/images/avatar/1.jpg',
     };
 
     mockPosts.unshift(newPost);
@@ -271,6 +280,9 @@ export const feedHandlers = [
       isLiked: false,
       title,
       content,
+      description: content.substring(0, 50),
+      userName: 'currentUser',
+      avatar: 'https://mui.com/static/images/avatar/1.jpg',
     };
 
     mockPosts.unshift(newPost);

--- a/src/pages/LikedReviewMorePage/LikedReviewMorePage.tsx
+++ b/src/pages/LikedReviewMorePage/LikedReviewMorePage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { Review } from '@shared/types/type';
+import { Review, OneLinePost } from '@shared/types/type';
 import ReviewMorePageTemplate from '@components/ReviewMorePage/ReviewMorePageTemplate';
 import { useGetLikedPaginatedFeedsQuery } from '@features/MyPage/api/userFeedsApi';
 
@@ -16,8 +16,19 @@ const LikedReviewMorePage = (): JSX.Element => {
 
   useEffect(() => {
     if (data?.feeds) {
-      setReviews((prevReviews) => [...prevReviews, ...data.feeds]);
-      if (data.feeds.length < 5) setHasMore(false);
+      // data.feeds에서 Review 타입으로 변환하여 설정
+      const newReviews = data.feeds
+        .filter((feed): feed is OneLinePost => feed.postType === '한줄평') // 한줄평만 필터링 +타입 가드 사용
+        .map((feed) => ({
+          username: feed.user.userName,
+          date: feed.createdAt,
+          content: feed.review,
+          likes: feed.likeCount,
+          rating: feed.rating || 0,
+        }));
+
+      setReviews((prevReviews) => [...prevReviews, ...newReviews]);
+      if (newReviews.length < 5) setHasMore(false);
     }
   }, [data]);
 

--- a/src/shared/types/type.ts
+++ b/src/shared/types/type.ts
@@ -34,6 +34,11 @@ export interface Post {
   book: Book;
   likeCount: number;
   isLiked: boolean;
+  postType: PostType;
+  title: string;
+  description: string;
+  userName: string;
+  avatar: string;
 }
 
 // 한줄평 포스트
@@ -46,10 +51,10 @@ export interface OneLinePost extends Post {
 // 일반 포스팅
 export interface Posting extends Post {
   postType: '포스팅';
-  title: string;
   content: string;
 }
 
+// 리뷰 데이터 타입
 export interface Review {
   username: string;
   date: string;
@@ -66,13 +71,6 @@ export interface Book {
   itemId: number;
 }
 
-export interface Bookshelf {
-  id: number;
-  name: string; // 책장 이름
-  bookCount: number; // 책 개수
-  books: Book[]; // 책 목록
-}
-
 // 저장된 책 interface
 export interface SavedBook extends Book {
   bookshelfId: number; // 책장 ID
@@ -87,15 +85,7 @@ export interface Bookshelf {
   createdAt: string;
   updatedAt: string;
   bookCount: number; // 책장에 저장된 책 수
-}
-
-// 리뷰 데이터 타입
-export interface Review {
-  username: string;
-  date: string;
-  content: string;
-  likes: number;
-  rating: number;
+  books: SavedBook[]; // 첵징에 자징된 책들 배열
 }
 
 // 책 상세페이지 성별 및 연령 데이터 타입


### PR DESCRIPTION
## 연관 이슈

> 연관된 이슈를 모두 기재 → #[Issue번호] 형식

- #151 
## 작업 요약

> 1~2줄 사이의 요약 설명
- 타입 불일치 및 오류 수정, 인터페이스 속성 추가, 내보내기 문제 해결, 경로 업데이트 및 리팩토링 작업 수행
## 작업 상세 설명

> 주요 기능 및 로직에 대한 설명을 작성
1. BookDetailPost와 PostMoreTemplate 간의 타입 불일치 해결
2. LikedReviewMorePage에서 발생한 타입 오류 수정
3. Post, OneLinePost, Posting 인터페이스에 누락된 속성 추가
4. ViewMode 및 SortOption의 네임드 내보내기 문제 해결
5. ViewMode 및 SortOption 타입의 import 경로 수정
6. postingDetailStyles 경로를 '@'를 사용하여 업데이트
7. snackbar 컴포넌트의 스토어 경로를 업데이트
8. BookReviewTab에서 Post 타입을 사용하도록 리팩토링
9. bookSearchApi.ts에서 BookResponse 인터페이스를 내보내도록 수정
## 리뷰 요구사항

> 리뷰 예상 시간 및 집중 리뷰 부분

리뷰 예상 시간: 꽤 시간 소요가 될것 같습니다. 일단 제가 build하면 오류는 없습니다
집중 리뷰 부분: 타입 수정 및 인터페이스 변경 사항, 내보내기 문제와 관련된 부분에 대한 리뷰를 부탁드립니다 
                       타입 정리를 이렇게 하는게 맞는지 모르겠네요..
