### PR TITLE
포스팅 작성 임시저장 로드 다이얼로그 표시 이슈 해결

### DIFF
--- a/src/components/PostingWritePage/PostingWrite.styles.ts
+++ b/src/components/PostingWritePage/PostingWrite.styles.ts
@@ -116,7 +116,7 @@ export const postingWriteStyles = {
     flexDirection: 'row !important',
     backgroundColor: 'transparent',
     padding: '1rem',
-    height: '80px',
+    height: '120px',
     cursor: 'default',
     boxShadow: '0 1px 4px rgba(0, 0, 0, 0.4)',
     '& .MuiCardMedia-root': {

--- a/src/components/PostingWritePage/PostingWrite.tsx
+++ b/src/components/PostingWritePage/PostingWrite.tsx
@@ -41,6 +41,7 @@ const PostingWrite = () => {
     setContent,
     setSelectedBook,
     isEditing,
+    !!bookFromDetail,
   );
 
   const currentPosting = {

--- a/src/components/PostingWritePage/PostingWrite.tsx
+++ b/src/components/PostingWritePage/PostingWrite.tsx
@@ -12,6 +12,8 @@ import NonTitleDialog from '@components/commons/NonTitleDialog';
 import { useTempSave } from '@hooks/useTempSave';
 
 import { useGetPostByIdQuery } from '@features/PostDetailPage/api/postingApi';
+import { TEMP_SAVE_STORAGE_KEY } from '@constants/postingWrite';
+import { TempSaveData } from './types';
 const PostingWrite = () => {
   const { postingId } = useParams();
   const location = useLocation();
@@ -50,6 +52,9 @@ const PostingWrite = () => {
     book: selectedBook || ({} as Book), // null 대신 빈 객체 사용
     userId: 1,
   };
+  useEffect(() => {
+    console.log('selectedBook updated:', selectedBook);
+  }, [selectedBook]);
 
   const { data: postData } = useGetPostByIdQuery(postingId!, {
     skip: !isEditing || !postingId,
@@ -60,8 +65,16 @@ const PostingWrite = () => {
       setTitle(postData.title);
       setContent(postData.content);
       setSelectedBook(postData.book);
-    } else if (!isEditing) {
-      setSelectedBook(bookFromDetail || null);
+    } else if (!isEditing && bookFromDetail) {
+      setSelectedBook(bookFromDetail);
+    } else if (!isEditing && !bookFromDetail) {
+      const tempPostingString = localStorage.getItem(TEMP_SAVE_STORAGE_KEY);
+      if (tempPostingString) {
+        const tempPosting: TempSaveData = JSON.parse(tempPostingString);
+        setTitle(tempPosting.title || '');
+        setContent(tempPosting.content || '');
+        setSelectedBook(tempPosting.selectedBook || null);
+      }
     }
   }, [isEditing, postData, bookFromDetail]);
 

--- a/src/hooks/useTempSave.ts
+++ b/src/hooks/useTempSave.ts
@@ -13,6 +13,7 @@ export const useTempSave = (
   setContent: (content: string) => void,
   setSelectedBook: (book: Book | null) => void,
   isEditing: boolean,
+  hasBookFromDetail: boolean,
 ) => {
   const [showLoadDialog, setShowLoadDialog] = useState(false);
   const [tempSaveDate, setTempSaveDate] = useState<Date | null>(null);
@@ -48,8 +49,8 @@ export const useTempSave = (
 
   // 컴포넌트 마운트시, 임시저장 글 적용
   useEffect(() => {
-    if (isEditing) {
-      // If editing, don't load from localStorage
+    if (isEditing || hasBookFromDetail) {
+      // If editing or we have a book from location state, don't load from localStorage
       return;
     }
 
@@ -62,7 +63,7 @@ export const useTempSave = (
         (tempPosting.selectedBook &&
           Object.keys(tempPosting.selectedBook).length > 0)
       ) {
-        setSelectedBook(tempPosting.selectedBook || bookFromDetail || null);
+        setSelectedBook(tempPosting.selectedBook || null);
         setTitle(tempPosting.title || '');
         setContent(tempPosting.content || '');
         setTempSaveDate(new Date(tempPosting.date));
@@ -70,10 +71,15 @@ export const useTempSave = (
       } else {
         localStorage.removeItem(TEMP_SAVE_STORAGE_KEY);
       }
-    } else {
-      setSelectedBook(bookFromDetail || null);
     }
-  }, [bookFromDetail, setSelectedBook, setTitle, setContent, isEditing]);
+  }, [
+    bookFromDetail,
+    setSelectedBook,
+    setTitle,
+    setContent,
+    isEditing,
+    hasBookFromDetail,
+  ]);
 
   // 변경사항 있을 때마다 임시저장
   useEffect(() => {

--- a/src/hooks/useTempSave.ts
+++ b/src/hooks/useTempSave.ts
@@ -50,7 +50,6 @@ export const useTempSave = (
   // 컴포넌트 마운트시, 임시저장 글 적용
   useEffect(() => {
     if (isEditing || hasBookFromDetail) {
-      // If editing or we have a book from location state, don't load from localStorage
       return;
     }
 
@@ -92,8 +91,15 @@ export const useTempSave = (
 
   // 설정한 정보 유지
   const loadTempPosting = useCallback(() => {
+    const tempPostingString = localStorage.getItem(TEMP_SAVE_STORAGE_KEY);
+    if (tempPostingString) {
+      const tempPosting: TempSaveData = JSON.parse(tempPostingString);
+      setTitle(tempPosting.title || '');
+      setContent(tempPosting.content || '');
+      setSelectedBook(tempPosting.selectedBook || null);
+    }
     setShowLoadDialog(false);
-  }, []);
+  }, [setTitle, setContent, setSelectedBook]);
 
   // 취소 누르면 데이터 초기화
   const ignoreTempPosting = useCallback(() => {


### PR DESCRIPTION
## 연관 이슈

- #164

## 작업 요약

- 책 상세페이지에서 포스팅 작성시, 임시저장 로드 다이얼로그가 표시되는 이슈 해결

## 작업 상세 설명

- location state 로 책 받아올 시(책 상세페이지에서 글 작성), 임시저장 및 로드가 되지 않도록 로직 수정

## 리뷰 요구사항

- 리뷰 예상 시간: 1분
