### PR TITLE
SEO 메타 태그 추가 및 라우트 경로 변경

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,14 @@
     <link rel="icon" type="image/svg+xml" href="/itda.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>잇다</title>
+
+    <meta name="description" content="독서를 즐기는 사람들의 소통 공간, 잇다. 책과 함께 새로운 인연을 만들고 성장하세요.">
+    <link rel="canonical" href="https://www.bookitda.store/">
+    
+    <meta property="og:title" content="잇다 - 온라인 독서 커뮤니티 플랫폼" />
+    <meta property="og:description" content="독서를 즐기는 사람들의 소통 공간" />
+    <meta property="og: url" content="https://www.bookitda.store/" />
+    <meta property="og:type" content="website" />
   </head>
   <body>
     <div id="root"></div>

--- a/src/components/Header/userMenu.tsx
+++ b/src/components/Header/userMenu.tsx
@@ -66,7 +66,7 @@ const UserMenu = () => {
         <MenuItem onClick={() => handleNavigation('/my-page')}>
           마이페이지
         </MenuItem>
-        <MenuItem onClick={() => handleNavigation('/edit-account')}>
+        <MenuItem onClick={() => handleNavigation('/profile/edit')}>
           개인정보수정
         </MenuItem>
         <MenuItem onClick={handleLogout}>로그아웃</MenuItem>

--- a/src/pages/EditAccountPage.tsx/EditAccountPage.tsx
+++ b/src/pages/EditAccountPage.tsx/EditAccountPage.tsx
@@ -60,7 +60,7 @@ const EditAccountPage = (): JSX.Element => {
   const dispatch = useDispatch<AppDispatch>();
 
   useEffect(() => {
-    if (!checkedPassword) navigate('/edit-account/passwordChk');
+    if (!checkedPassword) navigate('/profile/edit/passwordChk');
   }, [checkedPassword, navigate]);
 
   useEffect(() => {

--- a/src/pages/PasswordChkPage/PasswordChkPage.tsx
+++ b/src/pages/PasswordChkPage/PasswordChkPage.tsx
@@ -64,7 +64,7 @@ const PasswordChkPage = () => {
 
       if (response.success) {
         dispatch(setCheckedPassword(true));
-        navigate('/edit-account');
+        navigate('/profile/edit');
       } else {
         dispatch(
           showSnackbar({ message: response.message, severity: 'error' }),

--- a/src/routes/RoutePath.ts
+++ b/src/routes/RoutePath.ts
@@ -5,7 +5,7 @@ const RoutePaths = {
   FEED: '/feed',
   SEARCH: '/search',
   MY_PAGE: '/my-page',
-  EDIT_ACCOUNT: '/edit-account',
+  EDIT_ACCOUNT: '/profile/edit',
   BOOKSHELVES: '/bookshelves',
   POSTING: '/posting',
   POSTING_WRITE: '/posting/write',


### PR DESCRIPTION
## 연관 이슈

> 연관된 이슈를 모두 기재 → #[Issue번호] 형식
- #186 
## 작업 요약

> 1~2줄 사이의 요약 설명

SEO 메타 태그 추가 및 EDIT_ACCOUNT 라우트 경로 변경
## 작업 상세 설명

> 주요 기능 및 로직에 대한 설명을 작성

1. SEO 최적화:
- description 메타 태그 추가
- canonical 링크 추가
- Open Graph 메타 태그 최적화
2. 라우트 경로 변경:
- EDIT_ACCOUNT 경로를 '/edit-account'에서 '/profile/edit'로 변경
->posting_write, posting_edit처럼 계층 구조 사용
- 관련 컴포넌트 및 네비게이션 로직 업데이트

## 리뷰 요구사항

> 리뷰 예상 시간 및 집중 리뷰 부분

리뷰 예상 시간 : 10분 미만
집중 리뷰 부분 : HTML 구조 변경 및 메타 태그 추가 부분

➕경로 수정할게 딱히 있진 않아서 일단은 개인정보수정페이지만 수정하였는데 시중에 사이트를 찾아보니 my-page보단 myProfile 이런식으로 사용하던데 이대로 my-page해도 괜찮은지 아니면 수정할지 알려주세요
➕저희가 로고가 있지 않아서 메타 태그에 이미지가 없는 상태여서 로고나 아이콘 있으면 좋을 것 같아요
