### PR TITLE
카카오 회원가입 후 정보 입력 페이지 구현

### DIFF
--- a/src/components/AdditionalInfo/AdditionalInfo.styles.ts
+++ b/src/components/AdditionalInfo/AdditionalInfo.styles.ts
@@ -1,0 +1,28 @@
+import { styled } from '@mui/material/styles';
+import { Box, Button, BoxProps, Container } from '@mui/material';
+
+export const StyledContainer = styled(Container)(({ theme }) => ({
+  maxWidth: '600px', // maxWidth="sm"에 해당
+  padding: theme.spacing(2),
+  marginTop: theme.spacing(4),
+  display: 'flex',
+  flexDirection: 'column',
+}));
+
+export const FormContainer = styled(Box)<BoxProps>(() => ({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '16px',
+}));
+
+export const SubmitButton = styled(Button)(() => ({
+  marginTop: '16px',
+}));
+
+export const CheckDuplicateButton = styled(Button)(() => ({
+  marginTop: '16px',
+  whiteSpace: 'nowrap',
+  minWidth: 'auto',
+  padding: '6px 12px',
+  borderRadius: '4px',
+}));

--- a/src/components/AdditionalInfo/AdditionalInfo.tsx
+++ b/src/components/AdditionalInfo/AdditionalInfo.tsx
@@ -1,0 +1,179 @@
+import { useState } from 'react';
+import { useForm, Controller } from 'react-hook-form';
+import { useDispatch } from 'react-redux';
+import { showSnackbar } from '@features/Snackbar/snackbarSlice';
+import { yupResolver } from '@hookform/resolvers/yup';
+import * as yup from 'yup';
+import {
+  TextField,
+  Select,
+  MenuItem,
+  FormControl,
+  InputLabel,
+  FormHelperText,
+  Box,
+  Container,
+  Typography,
+} from '@mui/material';
+import { checkUserIdDuplicate } from '@utils/SignupPage/checkDuplicate';
+import { AdditionalInfoData } from './AdditionalInfo.types';
+import {
+  FormContainer,
+  SubmitButton,
+  CheckDuplicateButton,
+} from './AdditionalInfo.styles';
+
+const additionalInfoSchema = yup.object().shape({
+  userId: yup.string().required('아이디는 필수입니다'),
+  gender: yup.string().required('성별을 선택해주세요'),
+  age: yup
+    .number()
+    .positive('나이는 양수여야 합니다')
+    .required('나이를 입력해주세요'),
+});
+
+const AdditionalInfo = (): JSX.Element => {
+  const {
+    control,
+    handleSubmit,
+    formState: { errors },
+    getValues,
+  } = useForm<AdditionalInfoData>({
+    resolver: yupResolver(additionalInfoSchema),
+    mode: 'onChange',
+  });
+
+  const [isUserIdAvailable, setIsUserIdAvailable] = useState<boolean | null>(
+    null,
+  );
+  const dispatch = useDispatch();
+
+  const onSubmit = async (formData: AdditionalInfoData) => {
+    if (!isUserIdAvailable) {
+      dispatch(
+        showSnackbar({
+          message: '아이디 중복 확인을 해주세요.',
+          severity: 'error',
+        }),
+      );
+      return;
+    }
+
+    console.log('카카오 로그인 추가 정보:', formData);
+  };
+
+  const handleUserIdDuplicateCheck = async () => {
+    try {
+      const userId = getValues('userId');
+      const isAvailable = await checkUserIdDuplicate(userId);
+      setIsUserIdAvailable(isAvailable);
+      if (!isAvailable) {
+        dispatch(
+          showSnackbar({
+            message: '이미 사용 중인 아이디입니다.',
+            severity: 'error',
+          }),
+        );
+      } else {
+        dispatch(
+          showSnackbar({
+            message: '사용 가능한 아이디입니다.',
+            severity: 'success',
+          }),
+        );
+      }
+    } catch (error) {
+      console.error('ID 중복 확인 중 오류 발생:', error);
+      dispatch(
+        showSnackbar({
+          message: '중복 확인 중 오류가 발생했습니다.',
+          severity: 'error',
+        }),
+      );
+    }
+  };
+
+  return (
+    <Container
+      maxWidth="sm"
+      sx={{ p: 2, mt: '2rem', display: 'flex', flexDirection: 'column' }}
+    >
+      <Typography variant="h4" component="h1" gutterBottom align="center">
+        추가 정보 입력
+      </Typography>
+      <Box>
+        <FormContainer component="form" onSubmit={handleSubmit(onSubmit)}>
+          <Controller
+            name="userId"
+            control={control}
+            defaultValue=""
+            render={({ field }): JSX.Element => (
+              <Box display="flex" alignItems="center" gap={1}>
+                <TextField
+                  {...field}
+                  label="아이디"
+                  variant="outlined"
+                  fullWidth
+                  error={!!errors.userId}
+                  helperText={errors.userId?.message}
+                  onChange={(e) => {
+                    field.onChange(e);
+                    setIsUserIdAvailable(null);
+                  }}
+                />
+                <CheckDuplicateButton
+                  variant="contained"
+                  onClick={handleUserIdDuplicateCheck}
+                  disabled={false}
+                >
+                  중복확인
+                </CheckDuplicateButton>
+              </Box>
+            )}
+          />
+          <Controller
+            name="gender"
+            control={control}
+            defaultValue=""
+            render={({ field }): JSX.Element => (
+              <FormControl fullWidth error={!!errors.gender}>
+                <InputLabel>성별</InputLabel>
+                <Select {...field} label="성별">
+                  <MenuItem value="male">남성</MenuItem>
+                  <MenuItem value="female">여성</MenuItem>
+                </Select>
+                <FormHelperText>{errors.gender?.message}</FormHelperText>
+              </FormControl>
+            )}
+          />
+          <Controller
+            name="age"
+            control={control}
+            defaultValue={0}
+            render={({ field }): JSX.Element => (
+              <TextField
+                {...field}
+                label="나이"
+                type="number"
+                variant="outlined"
+                fullWidth
+                error={!!errors.age}
+                helperText={errors.age?.message}
+                onChange={(e) =>
+                  field.onChange(
+                    e.target.value === '' ? '' : Number(e.target.value),
+                  )
+                }
+              />
+            )}
+          />
+          <SubmitButton type="submit" variant="contained" fullWidth>
+            정보 제출
+          </SubmitButton>
+        </FormContainer>
+      </Box>
+    </Container>
+  );
+};
+
+export default AdditionalInfo;

--- a/src/components/AdditionalInfo/AdditionalInfo.types.ts
+++ b/src/components/AdditionalInfo/AdditionalInfo.types.ts
@@ -1,0 +1,13 @@
+import { Control, FieldErrors } from 'react-hook-form';
+
+export interface AdditionalInfoData {
+  userId: string;
+  gender: string;
+  age: number;
+}
+
+export interface AdditionalInfoProps {
+  control: Control<AdditionalInfoData>;
+  errors: FieldErrors<AdditionalInfoData>;
+  onSubmit: (data: AdditionalInfoData) => void;
+}

--- a/src/pages/AdditionalInfoPage/AdditionalInfoPage.tsx
+++ b/src/pages/AdditionalInfoPage/AdditionalInfoPage.tsx
@@ -1,0 +1,7 @@
+import AdditionalInfo from '@components/AdditionalInfo/AdditionalInfo';
+
+const AdditionalInfoPage = (): JSX.Element => {
+  return <AdditionalInfo />;
+};
+
+export default AdditionalInfoPage;

--- a/src/routes/RoutePath.ts
+++ b/src/routes/RoutePath.ts
@@ -14,6 +14,7 @@ const RoutePaths = {
   BOOKDETAIL: '/bookDetail',
   REVIEWS: 'reviews',
   POSTS: 'posts',
+  KAKAO_ADDITIONAL_INFO: '/kakao/additional-info',
   // 추가시
   // ABOUT: '/about', 식으로 가능
 };

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -17,6 +17,7 @@ import PostingWritePage from '@pages/PostingWritePage/PostingWritePage';
 import LikedPostMorePage from '@pages/LikedPostMorePage/LikedPostMorePage';
 import LikedReviewMorePage from '@pages/LikedReviewMorePage/LikedReviewMorePage';
 import MyPage from '@pages/MyPage/MyPage';
+import AdditionalInfoPage from '@pages/AdditionalInfoPage/AdditionalInfoPage';
 const AppRouter = () => {
   return (
     <Routes>
@@ -28,6 +29,10 @@ const AppRouter = () => {
       <Route path={`${RoutePaths.MY_PAGE}/:userId?`} element={<MyPage />} />
       <Route path="/oauth/kakao" element={<KakaoCallback />} />
       <Route path="/:userId" element={<MyPage />} />
+      <Route
+        path={RoutePaths.KAKAO_ADDITIONAL_INFO}
+        element={<AdditionalInfoPage />}
+      />
       <Route
         path={`${RoutePaths.EDIT_ACCOUNT}/passwordChk`}
         element={<PasswordChkPage />}


### PR DESCRIPTION
## 연관 이슈

> 연관된 이슈를 모두 기재 → #[Issue번호] 형식
- #188 
## 작업 요약

> 1~2줄 사이의 요약 설명

AdditionalInfo 컴포넌트 구현 및 라우팅 설정 업데이트
## 작업 상세 설명

> 주요 기능 및 로직에 대한 설명을 작성

1. AdditionalInfo 컴포넌트 구현
- 아이디, 성별, 나이 입력 폼 구현
- Yup을 사용한 폼 유효성 검사
- 아이디 중복 확인 기능 간단 구현
2. 라우팅 설정 업데이트
## 리뷰 요구사항

> 리뷰 예상 시간 및 집중 리뷰 부분

리뷰 예상 시간: 20분?
집중 리뷰 부분: 
제 기억상 회의 때 아이디, 성별, 나이 부분이 필요했다고 생각나서 일단은 세개만 넣었습니다. 더 필요한게 있다면 알려주세요.
제가 목요일에 프로젝트 작업 진행이 불가능할 것 같아서 일단은 최대한 간단하게만 구현했습니다.
## Preview 이미지 (필요시)

https://github.com/user-attachments/assets/816a3dc5-8c08-4b49-ba3c-24bf8b8cf55d

