### PR TITLE
더보기 페이지 삭제 관련 UI 구성

### DIFF
--- a/src/components/PostMorePage/PostMoreTemplate.tsx
+++ b/src/components/PostMorePage/PostMoreTemplate.tsx
@@ -1,6 +1,8 @@
+import { useState } from 'react';
 import PostCard from '@components/commons/PostCard';
 import InfiniteScrollComponent from '@components/commons/InfiniteScroll';
-import { Box, Typography } from '@mui/material';
+import { Box, Typography, Button, Checkbox, Stack } from '@mui/material';
+import DeleteIcon from '@mui/icons-material/Delete';
 import { BookDetailPost } from '@shared/types/type';
 
 interface PostMoreTemplateProps {
@@ -17,25 +19,91 @@ const PostMoreTemplate = ({
   fetchMoreData,
 }: PostMoreTemplateProps) => {
   const mockUser = { id: '1' };
+  const [isDeleteMode, setIsDeleteMode] = useState<boolean>(false);
+  const [selectedPosts, setSelectedPosts] = useState<number[]>([]);
+
+  const handleDeleteModeToggle = () => {
+    setIsDeleteMode(!isDeleteMode);
+    setSelectedPosts([]);
+  };
+
+  const handlePostSelect = (index: number) => {
+    setSelectedPosts((prev) =>
+      prev.includes(index) ? prev.filter((i) => i !== index) : [...prev, index],
+    );
+  };
+
+  const handleDeleteSelected = () => {
+    // 여기에 실제 삭제 로직을 구현합니다.
+    console.log('Deleting posts:', selectedPosts);
+    setIsDeleteMode(false);
+    setSelectedPosts([]);
+  };
+
   return (
     <Box sx={{ padding: '1rem', maxWidth: '1200px', margin: 'auto' }}>
-      <Typography variant="h5" fontWeight="bold" sx={{ marginBottom: '1rem' }}>
-        {`포스트 목록 (${totalPosts || 0}개)`}
-      </Typography>
+      <Stack
+        direction="row"
+        justifyContent="space-between"
+        alignItems="center"
+        marginBottom="1rem"
+      >
+        <Typography variant="h5" fontWeight="bold">
+          {`포스트 목록 (${totalPosts || 0}개)`}
+        </Typography>
+        <Stack direction="row" spacing={2}>
+          <Button
+            startIcon={<DeleteIcon />}
+            onClick={handleDeleteModeToggle}
+            color={isDeleteMode ? 'secondary' : 'primary'}
+            variant={isDeleteMode ? 'contained' : 'outlined'}
+            size="small"
+          >
+            {isDeleteMode ? '취소' : '삭제'}
+          </Button>
+          {isDeleteMode && (
+            <Button
+              variant="contained"
+              color="error"
+              onClick={handleDeleteSelected}
+              disabled={selectedPosts.length === 0}
+            >
+              선택 삭제 ({selectedPosts.length})
+            </Button>
+          )}
+        </Stack>
+      </Stack>
 
       <InfiniteScrollComponent
         items={posts}
         hasMore={hasMore}
         fetchMore={fetchMoreData}
         gridSize={{ xs: 12, md: 6 }}
-        renderItem={(post) => (
-          <PostCard
-            postId="postId"
-            title={post.title}
-            content="내용"
-            cover="커버"
-            user={mockUser}
-          />
+        renderItem={(post, index) => (
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'flex-start',
+              marginBottom: '1rem',
+            }}
+          >
+            {isDeleteMode && (
+              <Checkbox
+                checked={selectedPosts.includes(index)}
+                onChange={() => handlePostSelect(index)}
+                sx={{ padding: '4px', marginRight: '8px' }}
+              />
+            )}
+            <Box sx={{ flexGrow: 1 }}>
+              <PostCard
+                postId="postId"
+                title={post.title}
+                content="내용"
+                cover="커버"
+                user={mockUser}
+              />
+            </Box>
+          </Box>
         )}
       />
     </Box>

--- a/src/components/PostMorePage/PostMoreTemplate.tsx
+++ b/src/components/PostMorePage/PostMoreTemplate.tsx
@@ -78,7 +78,7 @@ const PostMoreTemplate = ({
         items={posts}
         hasMore={hasMore}
         fetchMore={fetchMoreData}
-        gridSize={{ xs: 12, md: 6 }}
+        gridSize={{ xs: 12, md: 12 }}
         renderItem={(post, index) => (
           <Box
             sx={{

--- a/src/components/ReviewMorePage/ReviewMorePageTemplate.tsx
+++ b/src/components/ReviewMorePage/ReviewMorePageTemplate.tsx
@@ -147,7 +147,7 @@ const ReviewMorePageTemplate: React.FC<ReviewMorePageTemplateProps> = ({
         items={sortedReviews}
         hasMore={hasMore}
         fetchMore={fetchMoreData}
-        gridSize={{ xs: 12, md: 12 }}
+        gridSize={{ xs: 12, md: 6 }}
         renderItem={(review, index) => (
           <Box
             sx={{

--- a/src/components/ReviewMorePage/ReviewMorePageTemplate.tsx
+++ b/src/components/ReviewMorePage/ReviewMorePageTemplate.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
-import { Box, Typography, Stack } from '@mui/material';
+import { Box, Typography, Stack, Button, Checkbox } from '@mui/material';
+import DeleteIcon from '@mui/icons-material/Delete';
 import StarRating from '@components/commons/StarRating';
 import ReviewSortOptions from '@components/ReviewMorePage/ReviewSortOptions';
 import InfiniteScrollComponent from '@components/commons/InfiniteScroll';
@@ -24,10 +25,12 @@ const ReviewMorePageTemplate: React.FC<ReviewMorePageTemplateProps> = ({
   fetchMoreData,
   bookDetails,
 }) => {
-  const [selectedRating, setSelectedRating] = useState<number>(0); // 별점 상태
-  const [isDialogOpen, setIsDialogOpen] = useState<boolean>(false); // 모달 상태
-  const [sortOption, setSortOption] = useState<string>('likes'); // 정렬 상태
-  const [sortedReviews, setSortedReviews] = useState<Review[]>(reviews); // 정렬된 리뷰
+  const [selectedRating, setSelectedRating] = useState<number>(0);
+  const [isDialogOpen, setIsDialogOpen] = useState<boolean>(false);
+  const [sortOption, setSortOption] = useState<string>('likes');
+  const [sortedReviews, setSortedReviews] = useState<Review[]>(reviews);
+  const [isDeleteMode, setIsDeleteMode] = useState<boolean>(false);
+  const [selectedReviews, setSelectedReviews] = useState<number[]>([]);
 
   useEffect(() => {
     const updatedReviews = [...reviews];
@@ -42,35 +45,44 @@ const ReviewMorePageTemplate: React.FC<ReviewMorePageTemplateProps> = ({
         (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime(),
       );
     }
-
     setSortedReviews(updatedReviews);
   }, [reviews, sortOption]);
 
-  // 별점 변경 처리
   const handleRatingChange = (rating: number) => {
     setSelectedRating(rating);
     setIsDialogOpen(true);
   };
 
-  // 모달 닫기 처리
   const handleModalClose = () => {
     setIsDialogOpen(false);
   };
 
-  // 정렬 옵션 변경 처리
   const handleSortChange = (option: string) => {
     setSortOption(option);
   };
 
+  const handleDeleteModeToggle = () => {
+    setIsDeleteMode(!isDeleteMode);
+    setSelectedReviews([]);
+  };
+
+  const handleReviewSelect = (index: number) => {
+    setSelectedReviews((prev) =>
+      prev.includes(index) ? prev.filter((i) => i !== index) : [...prev, index],
+    );
+  };
+
+  const handleDeleteSelected = () => {
+    const updatedReviews = sortedReviews.filter(
+      (_, index) => !selectedReviews.includes(index),
+    );
+    setSortedReviews(updatedReviews);
+    setSelectedReviews([]);
+    setIsDeleteMode(false);
+  };
+
   return (
-    <Box
-      sx={{
-        padding: '1rem',
-        maxWidth: '800px',
-        margin: 'auto',
-      }}
-    >
-      {/* StarRating 박스 */}
+    <Box sx={{ padding: '1rem', maxWidth: '800px', margin: 'auto' }}>
       {bookDetails && (
         <Box
           sx={{
@@ -99,7 +111,6 @@ const ReviewMorePageTemplate: React.FC<ReviewMorePageTemplateProps> = ({
         </Box>
       )}
 
-      {/* 제목 및 정렬 옵션 */}
       <Stack direction="row" justifyContent="space-between" marginBottom="1rem">
         <Typography
           variant="h5"
@@ -108,19 +119,57 @@ const ReviewMorePageTemplate: React.FC<ReviewMorePageTemplateProps> = ({
         >
           한 줄 리뷰 {sortedReviews.length}
         </Typography>
-        <ReviewSortOptions value={sortOption} onChange={handleSortChange} />
+        <Stack direction="row" spacing={2} alignItems="center">
+          <Button
+            startIcon={<DeleteIcon />}
+            onClick={handleDeleteModeToggle}
+            color={isDeleteMode ? 'secondary' : 'primary'}
+            variant={isDeleteMode ? 'contained' : 'outlined'}
+            size="small"
+          >
+            {isDeleteMode ? '취소' : '삭제'}
+          </Button>
+          {isDeleteMode && (
+            <Button
+              variant="contained"
+              color="error"
+              onClick={handleDeleteSelected}
+              disabled={selectedReviews.length === 0}
+            >
+              선택 삭제 ({selectedReviews.length})
+            </Button>
+          )}
+          <ReviewSortOptions value={sortOption} onChange={handleSortChange} />
+        </Stack>
       </Stack>
 
-      {/* 무한 스크롤 */}
       <InfiniteScrollComponent
-        items={sortedReviews} // 정렬된 리뷰를 전달
+        items={sortedReviews}
         hasMore={hasMore}
         fetchMore={fetchMoreData}
         gridSize={{ xs: 12, md: 12 }}
-        renderItem={(review) => <ReviewCard {...review} />}
+        renderItem={(review, index) => (
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'flex-start',
+              marginBottom: '1rem',
+            }}
+          >
+            {isDeleteMode && (
+              <Checkbox
+                checked={selectedReviews.includes(index)}
+                onChange={() => handleReviewSelect(index)}
+                sx={{ padding: '4px', marginRight: '8px' }}
+              />
+            )}
+            <Box sx={{ flexGrow: 1 }}>
+              <ReviewCard {...review} />
+            </Box>
+          </Box>
+        )}
       />
 
-      {/* 한 줄 리뷰 작성 모달 */}
       {bookDetails && (
         <OneLineReviewDialog
           isOpen={isDialogOpen}


### PR DESCRIPTION
## 연관 이슈

> 연관된 이슈를 모두 기재 → #[Issue번호] 형식
- #197 
## 작업 요약

> 1~2줄 사이의 요약 설명

리뷰 및 포스트 목록에서 삭제 기능 구현
## 작업 상세 설명

> 주요 기능 및 로직에 대한 설명을 작성

- ReviewMorePageTemplate과 PostMoreTemplate에 삭제 기능 추가
- 삭제 모드 토글 버튼 구현
- 체크박스를 통한 아이템 선택
- 선택된 아이템 삭제 기능 구현 (임시 로직)
## 리뷰 요구사항

> 리뷰 예상 시간 및 집중 리뷰 부분

예상 리뷰 시간: 20분
집중 리뷰 부분 : 
1. ReviewMorePageTemplate과 PostMoreTemplate에 삭제버튼을 추가했습니다. 지금은 상세페이지->더보기페이지랑 마이페이지 더보기 페이지 모두 삭제버튼이 뜹니다.
2. 임시 로직 구현한 상태라 다른 수정사항이 보인다면 알려주세요!
## Preview 이미지 (필요시)
1. 한줄평 더보기 페이지

https://github.com/user-attachments/assets/532d4e9a-a193-4ebe-aa91-98e8d5064f54

2. 포스팅 더보기 페이지

https://github.com/user-attachments/assets/4513ef02-8a2a-402b-ac70-75076ca8f420

