### PR TITLE
추가 정보 입력 페이지 & 정보 수정 페이지

### DIFF
--- a/src/components/AdditionalInfo/AdditionalInfo.tsx
+++ b/src/components/AdditionalInfo/AdditionalInfo.tsx
@@ -4,7 +4,6 @@ import { useDispatch } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
 import { showSnackbar } from '@features/Snackbar/snackbarSlice';
 import { yupResolver } from '@hookform/resolvers/yup';
-import * as yup from 'yup';
 import {
   TextField,
   Select,
@@ -25,16 +24,7 @@ import {
   CheckDuplicateButton,
 } from './AdditionalInfo.styles';
 import { useUpdateUserInfoMutation } from '@features/user/additionalInfoApi';
-
-const additionalInfoSchema = yup.object().shape({
-  userId: yup.string().required('아이디는 필수입니다'),
-  gender: yup.string().required('성별을 선택해주세요'),
-  age: yup
-    .number()
-    .positive('나이는 양수여야 합니다')
-    .integer('나이는 정수여야 합니다')
-    .required('나이를 입력해주세요'),
-});
+import { additionalInfoSchema } from '@utils/SignupPage/yupSchema';
 
 const AdditionalInfo = (): JSX.Element => {
   const {

--- a/src/components/LoginSignupPage/Login/Login.tsx
+++ b/src/components/LoginSignupPage/Login/Login.tsx
@@ -69,6 +69,7 @@ const Login = (): JSX.Element => {
             loginSuccess({
               id: data.user.id,
               email: data.user.email ?? '',
+              isSocialLogin: false,
             }),
           );
           dispatch(setToken(data.session.access_token));

--- a/src/components/LoginSignupPage/Signup/Signup.tsx
+++ b/src/components/LoginSignupPage/Signup/Signup.tsx
@@ -18,7 +18,7 @@ import { useState } from 'react';
 import PasswordInput from '../PasswordInput';
 import { StyledTitle, StyledSubmitButton, signupStyles } from './Signup.styles';
 import { SignupData } from '@features/SignupPage/types';
-import { schema } from '@utils/SignupPage/yupSchema';
+import { signupSchema } from '@utils/SignupPage/yupSchema';
 import { supabase } from '@utils/supabaseClient';
 import {
   checkEmailDuplicate,
@@ -33,7 +33,7 @@ const Signup = (): JSX.Element => {
     watch,
     formState: { errors },
   } = useForm<SignupData>({
-    resolver: yupResolver(schema),
+    resolver: yupResolver(signupSchema),
     mode: 'onChange',
   });
 

--- a/src/features/SNSLogin/auth/KakaoCallback.tsx
+++ b/src/features/SNSLogin/auth/KakaoCallback.tsx
@@ -44,6 +44,7 @@ const KakaoCallback = (): JSX.Element => {
               id: user.id,
               email: user.email,
               avatarUrl: avatar_url,
+              isSocialLogin: true,
             }),
           );
           dispatch(setToken(access_token));

--- a/src/features/user/additionalInfoApi.ts
+++ b/src/features/user/additionalInfoApi.ts
@@ -1,0 +1,35 @@
+import { createApi, fakeBaseQuery } from '@reduxjs/toolkit/query/react';
+import { supabase } from '@utils/supabaseClient';
+
+export const additionalInfoApi = createApi({
+  reducerPath: 'additionalInfoApi',
+  baseQuery: fakeBaseQuery(),
+  tagTypes: ['User'],
+  endpoints: (builder) => ({
+    updateUserInfo: builder.mutation({
+      async queryFn({ userId, formData }) {
+        try {
+          const { error } = await supabase
+            .from('user')
+            .update({
+              username: formData.userId,
+              gender: formData.gender,
+              age: formData.age,
+            })
+            .eq('id', userId);
+
+          if (error) {
+            return { error };
+          }
+
+          return { data: true };
+        } catch (err) {
+          return { error: { message: err } };
+        }
+      },
+      invalidatesTags: ['User'],
+    }),
+  }),
+});
+
+export const { useUpdateUserInfoMutation } = additionalInfoApi;

--- a/src/features/user/userApi.ts
+++ b/src/features/user/userApi.ts
@@ -1,68 +1,125 @@
-import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
-import { Account } from './types';
+import { createApi, fakeBaseQuery } from '@reduxjs/toolkit/query/react';
+import { supabase } from '@utils/supabaseClient';
 
 export const userApi = createApi({
   reducerPath: 'userApi',
-  baseQuery: fetchBaseQuery({ baseUrl: '/api' }),
+  baseQuery: fakeBaseQuery(), // fakeBaseQuery 사용
+  tagTypes: ['User'], // 캐싱 무효화를 위한 태그 설정
   endpoints: (builder) => ({
-    passwordCheck: builder.mutation<
-      { success: boolean; message: string },
-      { userId: string; password: string }
-    >({
-      query: ({ userId, password }) => ({
-        url: `user/${userId}/password-check`,
-        method: 'POST',
-        body: { password },
-      }),
-    }),
-
-    getUserInfo: builder.query<Account, string>({
-      query: (userId) => `user/${userId}`,
-    }),
-
-    updateUserInfo: builder.mutation<
-      { success: boolean; message: string },
-      { userId: string; field: string; value: string }
-    >({
-      query: ({ userId, field, value }) => ({
-        url: `user/${userId}`,
-        method: 'PUT',
-        body: { [field]: value },
-      }),
-    }),
-
-    uploadAvatar: builder.mutation<
-      { success: boolean; message: string; avatarUrl: string },
-      { userId: string; file: File }
-    >({
-      query: ({ userId, file }) => {
-        const formData = new FormData();
-        formData.append('avatar', file);
-
-        return {
-          url: `user/${userId}/avatar`,
-          method: 'POST',
-          body: formData,
-        };
+    getUserById: builder.query({
+      async queryFn(userId) {
+        try {
+          const { data, error } = await supabase
+            .from('user')
+            .select('*')
+            .eq('id', userId)
+            .single();
+          if (error) {
+            return { error };
+          }
+          return { data };
+        } catch (err) {
+          return { error: { message: err } };
+        }
       },
+      providesTags: ['User'],
+    }),
+    updateField: builder.mutation({
+      async queryFn({ userId, fieldName, value }) {
+        try {
+          console.log('Updating field:', fieldName, 'with value:', value);
+          console.log('Updating user with ID:', userId);
+
+          const { data, error } = await supabase
+            .from('user')
+            .update({ [fieldName]: value })
+            .eq('id', userId)
+            .select();
+
+          if (error) {
+            console.error('Supabase update error:', error);
+            return { error };
+          }
+
+          console.log('Update successful:', data);
+          return { data: true };
+        } catch (err) {
+          console.error('Unknown error occurred during update:', err);
+          return { error: { message: 'Unknown error occurred' } };
+        }
+      },
+      invalidatesTags: ['User'],
     }),
 
-    deleteAvatar: builder.mutation<
-      { success: boolean; message: string },
-      string
-    >({
-      query: (userId) => ({
-        url: `user/${userId}/avatar`,
-        method: 'DELETE',
-      }),
+    updateAvatar: builder.mutation({
+      async queryFn({ userId, file }) {
+        try {
+          const filePath = `${userId}/${Date.now()}_${file.name}`;
+          const { error } = await supabase.storage
+            .from('avatars')
+            .upload(filePath, file);
+
+          if (error) {
+            return { error };
+          }
+
+          const { data: publicUrlData } = supabase.storage
+            .from('avatars')
+            .getPublicUrl(filePath);
+          if (!publicUrlData?.publicUrl) {
+            return { error: { message: 'Failed to get public URL' } };
+          }
+
+          const { error: dbError } = await supabase
+            .from('user')
+            .update({ avatar_url: publicUrlData.publicUrl })
+            .eq('id', userId);
+
+          if (dbError) {
+            return { error: dbError };
+          }
+
+          return { data: publicUrlData.publicUrl }; // 성공적으로 반환된 URL
+        } catch (err) {
+          return { error: err };
+        }
+      },
+      invalidatesTags: ['User'], // 캐시 무효화
+    }),
+    deleteAvatarFile: builder.mutation({
+      async queryFn({ userId, avatarUrl }) {
+        try {
+          const oldAvatarPath = avatarUrl.split('/').slice(-2).join('/');
+          const { error } = await supabase.storage
+            .from('avatars')
+            .remove([oldAvatarPath]);
+
+          if (error) {
+            return { error };
+          }
+
+          const { error: dbError } = await supabase
+            .from('user')
+            .update({ avatar_url: '' })
+            .eq('id', userId);
+
+          if (dbError) {
+            return { error: dbError };
+          }
+
+          return { data: true }; // 성공적으로 삭제됨
+        } catch (err) {
+          return { error: err };
+        }
+      },
+      invalidatesTags: ['User'], // 캐시 무효화
     }),
   }),
 });
 
 export const {
-  usePasswordCheckMutation,
-  useGetUserInfoQuery,
-  useUpdateUserInfoMutation,
-  useUploadAvatarMutation,
-  useDeleteAvatarMutation,
+  useGetUserByIdQuery,
+  useUpdateFieldMutation,
+  useUpdateAvatarMutation,
+  useDeleteAvatarFileMutation,
 } = userApi;

--- a/src/features/user/userSlice.ts
+++ b/src/features/user/userSlice.ts
@@ -4,6 +4,7 @@ export interface UserInfo {
   id: string;
   email?: string;
   avatarUrl?: string;
+  isSocialLogin: boolean;
 }
 
 export interface UserState {
@@ -36,6 +37,11 @@ export const userSlice = createSlice({
       state.autoLogin = false;
       state.token = null;
     },
+    setAvatarUrl: (state, action: PayloadAction<string>) => {
+      if (state.userInfo) {
+        state.userInfo.avatarUrl = action.payload;
+      }
+    },
     setCheckedPassword(state, action: PayloadAction<boolean>) {
       state.checkedPassword = action.payload;
     },
@@ -51,6 +57,7 @@ export const userSlice = createSlice({
 export const {
   loginSuccess,
   logoutSuccess,
+  setAvatarUrl,
   setCheckedPassword,
   setAutoLogin,
   setToken,

--- a/src/features/user/userSlice.ts
+++ b/src/features/user/userSlice.ts
@@ -36,6 +36,7 @@ export const userSlice = createSlice({
       state.isLoggedIn = false;
       state.autoLogin = false;
       state.token = null;
+      state.checkedPassword = false;
     },
     setAvatarUrl: (state, action: PayloadAction<string>) => {
       if (state.userInfo) {

--- a/src/hooks/usePerformAutoLogin.ts
+++ b/src/hooks/usePerformAutoLogin.ts
@@ -15,10 +15,13 @@ export const usePerformAutoLogin = () => {
             data: { user },
           } = await supabase.auth.getUser(token);
           if (user) {
+            const providerType = user.app_metadata.provider;
+            const isSocialLogin = providerType === 'kakao';
             dispatch(
               loginSuccess({
                 id: user.id,
                 email: user.email,
+                isSocialLogin,
               }),
             );
             dispatch(setToken(token));

--- a/src/hooks/useSetAutoLogin.ts
+++ b/src/hooks/useSetAutoLogin.ts
@@ -10,6 +10,9 @@ export const useSetAutoLoginSettings = () => {
     const checkSettings = async () => {
       const session = await supabase.auth.getSession();
       if (session.data.session?.user) {
+        const providerType = session.data.session.user.app_metadata.provider;
+        const isSocialLogin = providerType === 'kakao';
+
         const { data: settings } = await supabase
           .from('user_settings')
           .select('auto_login')
@@ -21,6 +24,7 @@ export const useSetAutoLoginSettings = () => {
             loginSuccess({
               id: session.data.session.user.id,
               email: session.data.session.user.email ?? '',
+              isSocialLogin,
             }),
           );
           dispatch(setToken(session.data.session.access_token));

--- a/src/pages/EditAccountPage.tsx/EditAccountPage.tsx
+++ b/src/pages/EditAccountPage.tsx/EditAccountPage.tsx
@@ -12,6 +12,7 @@ import DeleteIcon from '@mui/icons-material/Delete';
 import { useDispatch, useSelector } from 'react-redux';
 import { RootState } from '@store/index';
 import {
+  useDeleteAccountMutation,
   useDeleteAvatarFileMutation,
   useGetUserByIdQuery,
   useUpdateAvatarMutation,
@@ -32,6 +33,7 @@ const EditAccountPage = (): JSX.Element => {
   const [updateField] = useUpdateFieldMutation();
   const [updateAvatar] = useUpdateAvatarMutation();
   const [deleteAvatar] = useDeleteAvatarFileMutation();
+  const [deleteAccount] = useDeleteAccountMutation();
 
   // 단일 필드 업데이트 핸들러
   const handleSubmit = async (fieldName: keyof typeof data) => {
@@ -122,6 +124,39 @@ const EditAccountPage = (): JSX.Element => {
         }),
       );
       console.error('아바타 삭제 실패:', err);
+    }
+  };
+
+  const handleAccountDeletion = async () => {
+    if (!userId) return;
+
+    const confirmation = window.confirm(
+      '정말로 계정을 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.',
+    );
+
+    if (!confirmation) return;
+
+    try {
+      const result = await deleteAccount({ userId }).unwrap();
+
+      if (result) {
+        dispatch(
+          showSnackbar({
+            message: '계정이 성공적으로 삭제되었습니다.',
+            severity: 'success',
+          }),
+        );
+
+        window.location.href = '/';
+      }
+    } catch (err) {
+      dispatch(
+        showSnackbar({
+          message: '계정 삭제 중 오류가 발생했습니다.',
+          severity: 'error',
+        }),
+      );
+      console.error('계정 삭제 실패:', err);
     }
   };
 
@@ -233,6 +268,22 @@ const EditAccountPage = (): JSX.Element => {
             변경
           </Button>
         </Stack>
+        <Button
+          variant="outlined"
+          startIcon={<DeleteIcon />}
+          onClick={handleAccountDeletion}
+          // UI 수정 필요
+          sx={{
+            backgroundColor: '#ff0000',
+            border: 'none',
+            color: '#ffffff',
+            '&:hover': {
+              backgroundColor: '#cc0000',
+            },
+          }}
+        >
+          회원 탈퇴
+        </Button>
       </Stack>
     </Container>
   );

--- a/src/pages/EditAccountPage.tsx/EditAccountPage.tsx
+++ b/src/pages/EditAccountPage.tsx/EditAccountPage.tsx
@@ -155,52 +155,10 @@ const EditAccountPage = (): JSX.Element => {
       </Stack>
 
       {/* 개인정보 수정 섹션 */}
-      <Stack>
-        <Typography variant="h6" fontWeight="bold" mb={4}>
+      <Stack gap={3}>
+        <Typography variant="h6" fontWeight="bold">
           개인정보 수정
         </Typography>
-
-        {/* 닉네임 */}
-        <Stack direction="row" alignItems="center" spacing={1} mb={3}>
-          <TextField
-            fullWidth
-            label="닉네임"
-            name="username"
-            defaultValue={data.username || ''}
-            // onBlur={() => handleSubmit('username')}
-          />
-          <Button variant="contained" onClick={() => handleSubmit('username')}>
-            변경하기
-          </Button>
-        </Stack>
-
-        {/* 이름 */}
-        <Stack direction="row" alignItems="center" spacing={1} mb={3}>
-          <TextField
-            fullWidth
-            label="이름"
-            name="name"
-            defaultValue={data.name || ''}
-            // onBlur={() => handleSubmit('name')}
-          />
-          <Button variant="contained" onClick={() => handleSubmit('name')}>
-            변경하기
-          </Button>
-        </Stack>
-
-        {/* 전화번호 */}
-        <Stack direction="row" alignItems="center" spacing={1} mb={3}>
-          <TextField
-            fullWidth
-            label="휴대폰 번호"
-            name="phone"
-            defaultValue={data.phone || ''}
-            // onBlur={() => handleSubmit('phone')}
-          />
-          <Button variant="contained" onClick={() => handleSubmit('phone')}>
-            변경하기
-          </Button>
-        </Stack>
 
         {/* 이메일 (읽기 전용) */}
         <TextField
@@ -211,18 +169,68 @@ const EditAccountPage = (): JSX.Element => {
           disabled
         />
 
+        {/* 닉네임 */}
+        <Stack direction="row" alignItems="center" spacing={1}>
+          <TextField
+            fullWidth
+            label="닉네임"
+            name="username"
+            defaultValue={data.username || ''}
+          />
+          <Button variant="contained" onClick={() => handleSubmit('username')}>
+            변경
+          </Button>
+        </Stack>
+
+        {/* 이름 */}
+        <Stack direction="row" alignItems="center" spacing={1}>
+          <TextField
+            fullWidth
+            label="이름"
+            name="name"
+            defaultValue={data.name || ''}
+          />
+          <Button variant="contained" onClick={() => handleSubmit('name')}>
+            변경
+          </Button>
+        </Stack>
+
+        {/* 전화번호 */}
+        <Stack direction="row" alignItems="center" spacing={1}>
+          <TextField
+            fullWidth
+            label="휴대폰 번호"
+            name="phone"
+            defaultValue={data.phone || ''}
+          />
+          <Button variant="contained" onClick={() => handleSubmit('phone')}>
+            변경
+          </Button>
+        </Stack>
+
         {/* 나이 */}
-        <Stack direction="row" alignItems="center" spacing={1} mt={3}>
+        <Stack direction="row" alignItems="center" spacing={1}>
           <TextField
             fullWidth
             label="나이"
             name="age"
             type="number"
             defaultValue={data.age ?? ''}
-            // onBlur={() => handleSubmit('age')}
           />
           <Button variant="contained" onClick={() => handleSubmit('age')}>
-            변경하기
+            변경
+          </Button>
+        </Stack>
+
+        <Stack direction="row" alignItems="center" spacing={1}>
+          <TextField
+            fullWidth
+            label="소개"
+            name="about"
+            defaultValue={data.about || ''}
+          />
+          <Button variant="contained" onClick={() => handleSubmit('about')}>
+            변경
           </Button>
         </Stack>
       </Stack>

--- a/src/pages/EditAccountPage.tsx/EditAccountPage.tsx
+++ b/src/pages/EditAccountPage.tsx/EditAccountPage.tsx
@@ -1,4 +1,3 @@
-import React, { useEffect, useState } from 'react';
 import {
   Container,
   Typography,
@@ -7,164 +6,145 @@ import {
   Button,
   Stack,
   IconButton,
-  styled,
 } from '@mui/material';
 import CameraAltIcon from '@mui/icons-material/CameraAlt';
 import DeleteIcon from '@mui/icons-material/Delete';
-import { useNavigate } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
-import { AppDispatch, RootState } from '@store/index';
-import { Account } from '@features/user/types';
+import { RootState } from '@store/index';
 import {
-  useDeleteAvatarMutation,
-  useGetUserInfoQuery,
-  useUpdateUserInfoMutation,
-  useUploadAvatarMutation,
+  useDeleteAvatarFileMutation,
+  useGetUserByIdQuery,
+  useUpdateAvatarMutation,
+  useUpdateFieldMutation,
 } from '@features/user/userApi';
 import { showSnackbar } from '@features/Snackbar/snackbarSlice';
-import { FetchBaseQueryError } from '@reduxjs/toolkit/query';
-
-const VisuallyHiddenInput = styled('input')({
-  clip: 'rect(0 0 0 0)',
-  clipPath: 'inset(50%)',
-  height: 1,
-  overflow: 'hidden',
-  position: 'absolute',
-  bottom: 0,
-  left: 0,
-  whiteSpace: 'nowrap',
-  width: 1,
-});
+import { setAvatarUrl } from '@features/user/userSlice';
 
 const EditAccountPage = (): JSX.Element => {
-  const mockUserId = 'user';
+  const userInfo = useSelector((state: RootState) => state.user.userInfo);
+  const userId = userInfo?.id;
+  const dispatch = useDispatch();
 
-  const [userInfoState, setUserInfoState] = useState<Account>({
-    userId: '',
-    password: '',
-    name: '',
-    phone: '',
-    avatarUrl: '',
+  const { data, refetch } = useGetUserByIdQuery(userId || '', {
+    skip: !userId,
   });
 
-  const checkedPassword = useSelector(
-    (state: RootState) => state.user.checkedPassword,
-  );
+  const [updateField] = useUpdateFieldMutation();
+  const [updateAvatar] = useUpdateAvatarMutation();
+  const [deleteAvatar] = useDeleteAvatarFileMutation();
 
-  const navigate = useNavigate();
-
-  const { data: userInfo } = useGetUserInfoQuery(mockUserId);
-  const [updateUserInfo] = useUpdateUserInfoMutation();
-  const [uploadAvatar] = useUploadAvatarMutation();
-  const [deleteAvatar] = useDeleteAvatarMutation();
-  const dispatch = useDispatch<AppDispatch>();
-
-  useEffect(() => {
-    if (!checkedPassword) navigate('/profile/edit/passwordChk');
-  }, [checkedPassword, navigate]);
-
-  useEffect(() => {
-    if (userInfo) {
-      setUserInfoState({ ...userInfo, password: '' });
-    }
-  }, [userInfo]);
-
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const { name, value } = e.target;
-    setUserInfoState((prev) => ({ ...prev, [name]: value }));
-  };
-
-  const handleSubmit = async (field: string) => {
+  // 단일 필드 업데이트 핸들러
+  const handleSubmit = async (fieldName: keyof typeof data) => {
+    const stringFieldName = String(fieldName);
     try {
-      const response = await updateUserInfo({
-        userId: mockUserId,
-        field,
-        value: userInfoState[field as keyof typeof userInfoState],
+      if (!data || !userId) return;
+
+      const newValue = (
+        document.querySelector(
+          `[name="${stringFieldName}"]`,
+        ) as HTMLInputElement
+      )?.value;
+
+      const result = await updateField({
+        userId,
+        fieldName,
+        value: newValue,
       }).unwrap();
-      dispatch(
-        showSnackbar({ message: response.message, severity: 'success' }),
-      );
-      if (field === '비밀번호') {
-        setUserInfoState((prev) => ({ ...prev, password: '' }));
+
+      if (result) {
+        dispatch(
+          showSnackbar({
+            message: `${stringFieldName}이(가) 성공적으로 업데이트되었습니다.`,
+            severity: 'success',
+          }),
+        );
+        refetch();
       }
     } catch (err) {
-      const error = err as FetchBaseQueryError;
-
+      console.error(`${stringFieldName} 업데이트 중 오류가 발생했습니다.`, err);
       dispatch(
         showSnackbar({
-          message: (error.data as { message: string }).message,
+          message: `${stringFieldName} 업데이트 중 오류가 발생했습니다.`,
           severity: 'error',
         }),
       );
     }
   };
 
+  // 아바타 업로드 핸들러
   const handleAvatarUpload = async (file: File) => {
     try {
-      const response = await uploadAvatar({
-        userId: mockUserId,
-        file,
-      }).unwrap();
+      if (!userId) return;
 
-      setUserInfoState((prev) => ({ ...prev, avatarUrl: response.avatarUrl }));
-      dispatch(
-        showSnackbar({
-          message: response.message,
-          severity: 'success',
-        }),
-      );
+      const updatedAvatarUrl = await updateAvatar({ userId, file }).unwrap();
+
+      if (updatedAvatarUrl) {
+        dispatch(setAvatarUrl(updatedAvatarUrl));
+
+        dispatch(
+          showSnackbar({
+            message: `프로필 사진이 업데이트 되었습니다.`,
+            severity: 'success',
+          }),
+        );
+        refetch();
+      }
     } catch (err) {
-      const error = err as FetchBaseQueryError;
       dispatch(
         showSnackbar({
-          message: (error.data as { message: string }).message,
+          message: `프로필 사진 업데이트 중 오류가 발생했습니다.`,
           severity: 'error',
         }),
       );
+      console.error('프로필 사진 업로드 실패:', err);
     }
   };
 
+  // 아바타 삭제 핸들러
   const handleAvatarDelete = async () => {
     try {
-      const response = await deleteAvatar(mockUserId).unwrap();
-      setUserInfoState((prev) => ({ ...prev, avatarUrl: '' }));
+      if (!data?.avatar_url || !userId) return;
+
+      await deleteAvatar({ userId, avatarUrl: data.avatar_url }).unwrap();
+      dispatch(setAvatarUrl(''));
       dispatch(
         showSnackbar({
-          message: response.message,
+          message: `프로필 사진이 삭제되었습니다.`,
           severity: 'success',
         }),
       );
+      refetch();
     } catch (err) {
-      const error = err as FetchBaseQueryError;
       dispatch(
         showSnackbar({
-          message: (error.data as { message: string }).message,
+          message: `프로필 사진 삭제 중 오류가 발생했습니다.`,
           severity: 'error',
         }),
       );
+      console.error('아바타 삭제 실패:', err);
     }
   };
+
+  if (!data) return <Typography>로딩 중...</Typography>;
 
   return (
     <Container maxWidth="sm" sx={{ mt: 6 }}>
+      {/* 아바타 섹션 */}
       <Stack alignItems="center" spacing={1} mb={3}>
         <Avatar
-          src={userInfoState.avatarUrl}
+          src={data.avatar_url}
           alt="avatar"
-          sx={{
-            width: 96,
-            height: 96,
-          }}
+          sx={{ width: 96, height: 96 }}
         />
         <Stack direction="row" spacing={1}>
           <IconButton component="label">
             <CameraAltIcon />
-            <VisuallyHiddenInput
+            <input
               type="file"
+              style={{ display: 'none' }}
               onChange={(event) => {
-                if (event.target.files) {
+                if (event.target.files)
                   handleAvatarUpload(event.target.files[0]);
-                }
               }}
             />
           </IconButton>
@@ -174,81 +154,74 @@ const EditAccountPage = (): JSX.Element => {
         </Stack>
       </Stack>
 
+      {/* 개인정보 수정 섹션 */}
       <Stack>
-        <Stack alignItems="center">
-          <Typography variant="h6" fontWeight="bold" mb={4}>
-            개인정보 수정
-          </Typography>
-        </Stack>
-
-        <Typography variant="subtitle1" fontWeight="bold" mb={1}>
-          회원 정보
+        <Typography variant="h6" fontWeight="bold" mb={4}>
+          개인정보 수정
         </Typography>
 
+        {/* 닉네임 */}
+        <Stack direction="row" alignItems="center" spacing={1} mb={3}>
+          <TextField
+            fullWidth
+            label="닉네임"
+            name="username"
+            defaultValue={data.username || ''}
+            // onBlur={() => handleSubmit('username')}
+          />
+          <Button variant="contained" onClick={() => handleSubmit('username')}>
+            변경하기
+          </Button>
+        </Stack>
+
+        {/* 이름 */}
         <Stack direction="row" alignItems="center" spacing={1} mb={3}>
           <TextField
             fullWidth
             label="이름"
             name="name"
-            value={userInfoState.name}
-            onChange={handleChange}
+            defaultValue={data.name || ''}
+            // onBlur={() => handleSubmit('name')}
           />
-          <Button
-            variant="contained"
-            color="primary"
-            sx={{ width: '100px', height: '50px' }}
-            onClick={() => handleSubmit('이름')}
-          >
+          <Button variant="contained" onClick={() => handleSubmit('name')}>
             변경하기
           </Button>
         </Stack>
 
+        {/* 전화번호 */}
         <Stack direction="row" alignItems="center" spacing={1} mb={3}>
           <TextField
             fullWidth
             label="휴대폰 번호"
             name="phone"
-            value={userInfoState.phone}
-            onChange={handleChange}
+            defaultValue={data.phone || ''}
+            // onBlur={() => handleSubmit('phone')}
           />
-          <Button
-            variant="contained"
-            color="primary"
-            sx={{ width: '100px', height: '50px' }}
-            onClick={() => handleSubmit('휴대폰 번호')}
-          >
+          <Button variant="contained" onClick={() => handleSubmit('phone')}>
             변경하기
           </Button>
         </Stack>
 
-        <Typography variant="subtitle1" fontWeight="bold" mb={1}>
-          계정 정보
-        </Typography>
-
+        {/* 이메일 (읽기 전용) */}
         <TextField
-          sx={{ mb: 3 }}
           fullWidth
-          label="아이디"
-          name="userId"
-          value={userInfoState.userId}
+          label="이메일"
+          name="email"
+          defaultValue={data.email || ''}
           disabled
         />
 
-        <Stack direction="row" alignItems="center" spacing={1} mb={3}>
+        {/* 나이 */}
+        <Stack direction="row" alignItems="center" spacing={1} mt={3}>
           <TextField
             fullWidth
-            type="password"
-            label="비밀번호"
-            name="password"
-            value={userInfoState.password}
-            onChange={handleChange}
+            label="나이"
+            name="age"
+            type="number"
+            defaultValue={data.age ?? ''}
+            // onBlur={() => handleSubmit('age')}
           />
-          <Button
-            variant="contained"
-            color="primary"
-            sx={{ width: '100px', height: '50px' }}
-            onClick={() => handleSubmit('비밀번호')}
-          >
+          <Button variant="contained" onClick={() => handleSubmit('age')}>
             변경하기
           </Button>
         </Stack>

--- a/src/pages/PasswordChkPage/PasswordChkPage.tsx
+++ b/src/pages/PasswordChkPage/PasswordChkPage.tsx
@@ -7,101 +7,86 @@ import {
   Stack,
 } from '@mui/material';
 import LockIcon from '@mui/icons-material/Lock';
-import { useState, useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useState } from 'react';
+import { supabase } from '@utils/supabaseClient';
 import { useDispatch } from 'react-redux';
-import { AppDispatch } from '@store/index';
 import { setCheckedPassword } from '@features/user/userSlice';
-// import { usePasswordCheckMutation } from '@features/user/userApi';
+import { useNavigate } from 'react-router-dom';
+import RoutePaths from 'src/routes/RoutePath';
 import { showSnackbar } from '@features/Snackbar/snackbarSlice';
-import { FetchBaseQueryError } from '@reduxjs/toolkit/query/react';
 
 const PasswordChkPage = () => {
   const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+  const dispatch = useDispatch();
   const navigate = useNavigate();
-  // const [passwordCheck] = usePasswordCheckMutation();
-  const dispatch = useDispatch<AppDispatch>();
 
-  const [userId, setUserId] = useState('');
+  const handlePasswordCheck = async () => {
+    try {
+      const {
+        data: { session },
+      } = await supabase.auth.getSession();
 
-  useEffect(() => {
-    const userInfo = localStorage.getItem('userInfo');
-    if (userInfo) {
-      const parsedUserInfo = JSON.parse(userInfo);
-      if (Array.isArray(parsedUserInfo) && parsedUserInfo.length > 0) {
-        setUserId(parsedUserInfo[0].userId); // 배열의 첫 번째 요소에서 userId 설정
-      } else {
+      if (!session?.user?.email) {
         dispatch(
           showSnackbar({
-            message: '사용자 정보를 찾을 수 없습니다.',
+            message: '사용자 정보를 가져올 수 없습니다.',
             severity: 'error',
           }),
         );
-        navigate('/login');
+        return;
       }
-    } else {
-      navigate('/login');
+
+      const email = session.user.email;
+
+      const { error: signInError } = await supabase.auth.signInWithPassword({
+        email,
+        password,
+      });
+
+      if (signInError) {
+        dispatch(
+          showSnackbar({
+            message: '비밀번호가 올바르지 않습니다.',
+            severity: 'error',
+          }),
+        );
+        return;
+      }
+
+      dispatch(setCheckedPassword(true));
+      navigate(RoutePaths.EDIT_ACCOUNT);
+    } catch (err) {
+      console.error('비밀번호 확인 중 오류 발생:', err);
+      dispatch(
+        showSnackbar({
+          message: '오류가 발생했습니다. 다시 시도해주세요.',
+          severity: 'error',
+        }),
+      );
     }
-  }, [navigate, dispatch]);
+  };
 
-  // const handlePasswordCheck = async () => {
-  //   console.log('Checking password for userId:', userId);
-  //   if (!userId) {
-  //     dispatch(
-  //       showSnackbar({
-  //         message: '사용자 정보를 찾을 수 없습니다.',
-  //         severity: 'error',
-  //       }),
-  //     );
-  //     return;
-  //   }
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      handlePasswordCheck();
+    }
+  };
 
-  //   try {
-  //     const response = await passwordCheck({
-  //       userId,
-  //       password,
-  //     }).unwrap();
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setPassword(e.target.value);
+    setError('');
+  };
 
-  //     if (response.success) {
-  //       dispatch(setCheckedPassword(true));
-  //       navigate('/profile/edit');
-  //     } else {
-  //       dispatch(
-  //         showSnackbar({ message: response.message, severity: 'error' }),
-  //       );
-  //     }
-  //   } catch (err) {
-  //     const error = err as FetchBaseQueryError;
-
-  //     dispatch(
-  //       showSnackbar({
-  //         message:
-  //           (error.data as { message: string }).message ||
-  //           '비밀번호 확인 중 오류가 발생했습니다.',
-  //         severity: 'error',
-  //       }),
-  //     );
-  //   }
-  // };
-
-  // const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-  //   if (e.key === 'Enter') {
-  //     handlePasswordCheck();
-  //   }
-  // };
-
-  // const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-  //   setPassword(e.target.value);
-  // };
-
-  // const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
-  //   e.preventDefault();
-  //   handlePasswordCheck();
-  // };
+  // 폼 제출 처리
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    handlePasswordCheck();
+  };
 
   return (
     <Container maxWidth="sm" sx={{ mt: 6 }}>
-      {/* <Stack textAlign="center" mb={4}>
+      <Stack textAlign="center" mb={4}>
         <Avatar
           sx={{
             width: 96,
@@ -130,6 +115,8 @@ const PasswordChkPage = () => {
           onChange={handleChange}
           onKeyDown={handleKeyDown}
           variant="outlined"
+          error={!!error}
+          helperText={error}
           sx={{ mb: 3 }}
         />
         <Button
@@ -141,7 +128,7 @@ const PasswordChkPage = () => {
         >
           확인
         </Button>
-      </Stack> */}
+      </Stack>
     </Container>
   );
 };

--- a/src/pages/PasswordChkPage/PasswordChkPage.tsx
+++ b/src/pages/PasswordChkPage/PasswordChkPage.tsx
@@ -12,14 +12,14 @@ import { useNavigate } from 'react-router-dom';
 import { useDispatch } from 'react-redux';
 import { AppDispatch } from '@store/index';
 import { setCheckedPassword } from '@features/user/userSlice';
-import { usePasswordCheckMutation } from '@features/user/userApi';
+// import { usePasswordCheckMutation } from '@features/user/userApi';
 import { showSnackbar } from '@features/Snackbar/snackbarSlice';
 import { FetchBaseQueryError } from '@reduxjs/toolkit/query/react';
 
 const PasswordChkPage = () => {
   const [password, setPassword] = useState('');
   const navigate = useNavigate();
-  const [passwordCheck] = usePasswordCheckMutation();
+  // const [passwordCheck] = usePasswordCheckMutation();
   const dispatch = useDispatch<AppDispatch>();
 
   const [userId, setUserId] = useState('');
@@ -44,64 +44,64 @@ const PasswordChkPage = () => {
     }
   }, [navigate, dispatch]);
 
-  const handlePasswordCheck = async () => {
-    console.log('Checking password for userId:', userId);
-    if (!userId) {
-      dispatch(
-        showSnackbar({
-          message: '사용자 정보를 찾을 수 없습니다.',
-          severity: 'error',
-        }),
-      );
-      return;
-    }
+  // const handlePasswordCheck = async () => {
+  //   console.log('Checking password for userId:', userId);
+  //   if (!userId) {
+  //     dispatch(
+  //       showSnackbar({
+  //         message: '사용자 정보를 찾을 수 없습니다.',
+  //         severity: 'error',
+  //       }),
+  //     );
+  //     return;
+  //   }
 
-    try {
-      const response = await passwordCheck({
-        userId,
-        password,
-      }).unwrap();
+  //   try {
+  //     const response = await passwordCheck({
+  //       userId,
+  //       password,
+  //     }).unwrap();
 
-      if (response.success) {
-        dispatch(setCheckedPassword(true));
-        navigate('/profile/edit');
-      } else {
-        dispatch(
-          showSnackbar({ message: response.message, severity: 'error' }),
-        );
-      }
-    } catch (err) {
-      const error = err as FetchBaseQueryError;
+  //     if (response.success) {
+  //       dispatch(setCheckedPassword(true));
+  //       navigate('/profile/edit');
+  //     } else {
+  //       dispatch(
+  //         showSnackbar({ message: response.message, severity: 'error' }),
+  //       );
+  //     }
+  //   } catch (err) {
+  //     const error = err as FetchBaseQueryError;
 
-      dispatch(
-        showSnackbar({
-          message:
-            (error.data as { message: string }).message ||
-            '비밀번호 확인 중 오류가 발생했습니다.',
-          severity: 'error',
-        }),
-      );
-    }
-  };
+  //     dispatch(
+  //       showSnackbar({
+  //         message:
+  //           (error.data as { message: string }).message ||
+  //           '비밀번호 확인 중 오류가 발생했습니다.',
+  //         severity: 'error',
+  //       }),
+  //     );
+  //   }
+  // };
 
-  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === 'Enter') {
-      handlePasswordCheck();
-    }
-  };
+  // const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+  //   if (e.key === 'Enter') {
+  //     handlePasswordCheck();
+  //   }
+  // };
 
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setPassword(e.target.value);
-  };
+  // const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+  //   setPassword(e.target.value);
+  // };
 
-  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-    handlePasswordCheck();
-  };
+  // const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+  //   e.preventDefault();
+  //   handlePasswordCheck();
+  // };
 
   return (
     <Container maxWidth="sm" sx={{ mt: 6 }}>
-      <Stack textAlign="center" mb={4}>
+      {/* <Stack textAlign="center" mb={4}>
         <Avatar
           sx={{
             width: 96,
@@ -141,7 +141,7 @@ const PasswordChkPage = () => {
         >
           확인
         </Button>
-      </Stack>
+      </Stack> */}
     </Container>
   );
 };

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -45,10 +45,14 @@ const AppRouter = () => {
       <Route
         path={RoutePaths.EDIT_ACCOUNT}
         element={
-          userInfo?.isSocialLogin || checkedPassword ? (
-            <EditAccountPage />
+          userInfo ? (
+            userInfo.isSocialLogin || checkedPassword ? (
+              <EditAccountPage />
+            ) : (
+              <Navigate to={`${RoutePaths.EDIT_ACCOUNT}/passwordChk`} replace />
+            )
           ) : (
-            <Navigate to={`${RoutePaths.EDIT_ACCOUNT}/passwordChk`} replace />
+            <div>Loading...</div>
           )
         }
       />

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,4 +1,4 @@
-import { Routes, Route } from 'react-router-dom';
+import { Routes, Route, Navigate } from 'react-router-dom';
 import LoginSignup from '@pages/LoginSignupPage/LoginPage';
 import SignupPage from '@pages/LoginSignupPage/SignupPage';
 import FeedPage from '@pages/MainPage/Main';
@@ -18,7 +18,12 @@ import LikedPostMorePage from '@pages/LikedPostMorePage/LikedPostMorePage';
 import LikedReviewMorePage from '@pages/LikedReviewMorePage/LikedReviewMorePage';
 import MyPage from '@pages/MyPage/MyPage';
 import AdditionalInfoPage from '@pages/AdditionalInfoPage/AdditionalInfoPage';
+import { RootState } from '@store/index';
+import { useSelector } from 'react-redux';
 const AppRouter = () => {
+  const { userInfo, checkedPassword } = useSelector(
+    (state: RootState) => state.user,
+  );
   return (
     <Routes>
       <Route path={RoutePaths.MAIN} element={<FeedPage />} />
@@ -38,8 +43,14 @@ const AppRouter = () => {
         element={<PasswordChkPage />}
       />
       <Route
-        path={`${RoutePaths.EDIT_ACCOUNT}`}
-        element={<EditAccountPage />}
+        path={RoutePaths.EDIT_ACCOUNT}
+        element={
+          userInfo?.isSocialLogin || checkedPassword ? (
+            <EditAccountPage />
+          ) : (
+            <Navigate to={`${RoutePaths.EDIT_ACCOUNT}/passwordChk`} replace />
+          )
+        }
       />
       <Route
         path={`${RoutePaths.BOOKDETAIL}/:isbn`}

--- a/src/shared/types/type.ts
+++ b/src/shared/types/type.ts
@@ -27,6 +27,19 @@ export interface User {
   isFollower?: boolean;
 }
 
+// UserInfo 인터페이스 정의
+export interface UserInfo {
+  id: string;
+  username: string;
+  name: string;
+  phone: string;
+  gender: string;
+  avatarUrl: string;
+  about: string;
+  age: number | null;
+  email: string;
+}
+
 // 게시물 interface
 export interface Post {
   id: string; // Supabase의 UUID

--- a/src/store/index.tsx
+++ b/src/store/index.tsx
@@ -28,6 +28,7 @@ import { followApi } from '@features/commons/followApi';
 import feedReducer from '@features/FeedPage/slice/feedSlice';
 import { likeApi } from '@features/commons/likeApi';
 import { bookSearchByIsbnApi } from '@features/commons/bookSearchByIsbn';
+import { additionalInfoApi } from '@features/user/additionalInfoApi';
 
 export const store = configureStore({
   reducer: {
@@ -53,6 +54,7 @@ export const store = configureStore({
     [feedApi.reducerPath]: feedApi.reducer,
     [postingWriteApi.reducerPath]: postingWriteApi.reducer,
     [userApi.reducerPath]: userApi.reducer,
+    [additionalInfoApi.reducerPath]: additionalInfoApi.reducer,
     [mypageFollowApi.reducerPath]: mypageFollowApi.reducer,
     [followApi.reducerPath]: followApi.reducer,
     [likeApi.reducerPath]: likeApi.reducer,
@@ -82,6 +84,7 @@ export const store = configureStore({
       postingWriteApi.middleware,
       mypageFollowApi.middleware,
       userApi.middleware,
+      additionalInfoApi.middleware,
       followApi.middleware,
       likeApi.middleware,
     ]),

--- a/src/utils/SignupPage/yupSchema.ts
+++ b/src/utils/SignupPage/yupSchema.ts
@@ -1,7 +1,7 @@
 import { SignupData } from '@features/SignupPage/types';
 import * as yup from 'yup';
 
-export const schema = yup.object<SignupData>().shape({
+export const signupSchema = yup.object<SignupData>().shape({
   name: yup.string().required('이름을 입력해주세요'),
   userId: yup
     .string()
@@ -30,4 +30,14 @@ export const schema = yup.object<SignupData>().shape({
     .required('나이를 입력해주세요')
     .positive('나이는 양수여야 합니다')
     .integer('나이는 정수여야 합니다'),
+});
+
+export const additionalInfoSchema = yup.object().shape({
+  userId: yup.string().required('아이디는 필수입니다'),
+  gender: yup.string().required('성별을 선택해주세요'),
+  age: yup
+    .number()
+    .positive('나이는 양수여야 합니다')
+    .integer('나이는 정수여야 합니다')
+    .required('나이를 입력해주세요'),
 });

--- a/src/utils/deleteUserFiles.ts
+++ b/src/utils/deleteUserFiles.ts
@@ -1,0 +1,41 @@
+import { supabase } from './supabaseClient';
+
+async function deleteUserFiles(userId: string) {
+  try {
+    const bucketName = 'avatars';
+    const folderPath = `${userId}/`;
+
+    const { data: files, error: listError } = await supabase.storage
+      .from(bucketName)
+      .list(folderPath);
+
+    if (listError) {
+      console.error('파일 목록 가져오기 오류:', listError);
+      return false;
+    }
+
+    if (files.length === 0) {
+      console.log('삭제할 파일이 없습니다.');
+      return true;
+    }
+
+    const filePaths = files.map((file) => `${folderPath}${file.name}`);
+
+    const { error: deleteError } = await supabase.storage
+      .from(bucketName)
+      .remove(filePaths);
+
+    if (deleteError) {
+      console.error('파일 삭제 오류:', deleteError);
+      return false;
+    }
+
+    console.log('모든 파일이 성공적으로 삭제되었습니다.');
+    return true;
+  } catch (err) {
+    console.error('알 수 없는 오류 발생:', err);
+    return false;
+  }
+}
+
+export default deleteUserFiles;


### PR DESCRIPTION
## 연관 이슈

- #196 #198 #202

## 작업 요약

- sns 로그인 시 추가 정보 입력 페이지로 이동
- 정보 수정 페이지 구현

## 작업 상세 설명

- 추가 정보 입력 페이지
  - 추가 정보 입력 API 구현
- 정보 수정 페이지
  - 이메일 / SNS 로그인 시 조건부로 비밀번호 확인 페이지로 이동
  - SNS 로그인 시 첫 로그인에만 카카오톡 프로필 사진 적용
  - 유저 정보 수정 API 구현
  - 회원 탈퇴 기능 구현

## 리뷰 요구사항

- 10분
