### PR TITLE
Deprecated된 artifact actions로 인한 버그 픽스

### DIFF
--- a/.github/workflows/storybook-tests.yml
+++ b/.github/workflows/storybook-tests.yml
@@ -197,7 +197,7 @@ jobs:
             "npx wait-on tcp:6006 && npm run test-storybook -- --coverage"
       - name: Upload coverage report
         if: env.STORIES_FOUND == 'true'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: storybook-coverage
           path: coverage


### PR DESCRIPTION
## 연관 이슈

- Close #209

## 작업 요약

- 기존에 사용하였던 artifact v3가 deprecated 되어 v4로 마이그레이션 해주었습니다.

## 작업 상세 설명
- <img width="962" alt="image" src="https://github.com/user-attachments/assets/034dc0cc-8027-4d8d-9c2c-c9379731c06c" />
   위 문제 해결 완료하였습니다.
- [참고 자료](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/)

## 리뷰 요구사항

- 1분
- artifact 버전 외 playwright 서버 관련한 문제 발생하는데 별도 PR에서 해결 예정입니다! (현재 2군데에서 실패하는 건 playwright 서버 관련!) #214
