### PR TITLE
깃헙 액션 스토리북 서버 실행 캐싱 문제로 인한 실패 해결

### DIFF
--- a/.github/workflows/storybook-tests.yml
+++ b/.github/workflows/storybook-tests.yml
@@ -24,20 +24,9 @@ jobs:
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-node-
-      - name: Cache Playwright Browsers
-        uses: actions/cache@v4
-        id: playwright-cache
-        with:
-          path: ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-playwright-
       - name: Install dependencies if cache invalid
         if: steps.node-cache.outputs.cache-hit != 'true'
         run: npm ci
-      - name: Install Playwright browsers if cache invalid
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
-        run: npx playwright install --with-deps
 
   # Run interaction and accessibility tests
   interaction-and-accessibility:
@@ -59,14 +48,8 @@ jobs:
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-node-
-      - name: Restore Playwright Browsers
-        uses: actions/cache@v4
-        id: playwright-cache
-        with:
-          path: ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-playwright-
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps
       - name: Update Node.js dependencies
         run: |
           npm update
@@ -111,14 +94,8 @@ jobs:
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-node-
-      - name: Restore Playwright Browsers
-        uses: actions/cache@v4
-        id: playwright-cache
-        with:
-          path: ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-playwright-
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps
       - name: Check for Storybook stories
         id: check-stories
         run: |
@@ -154,14 +131,8 @@ jobs:
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-node-
-      - name: Restore Playwright Browsers
-        uses: actions/cache@v4
-        id: playwright-cache
-        with:
-          path: ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-playwright-
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps
       - name: Start the development server
         run: npm run dev &
       - name: Check for Playwright tests
@@ -195,14 +166,8 @@ jobs:
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-node-
-      - name: Restore Playwright Browsers
-        uses: actions/cache@v4
-        id: playwright-cache
-        with:
-          path: ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-playwright-
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps
       - name: Update Node.js dependencies
         run: |
           npm update

--- a/.github/workflows/storybook-tests.yml
+++ b/.github/workflows/storybook-tests.yml
@@ -16,20 +16,27 @@ jobs:
     steps:
       - name: Checkout Commit
         uses: actions/checkout@v4
-      - name: Cache NPM dependencies and Playwright
+      - name: Cache Node modules
         uses: actions/cache@v4
-        id: npm-cache
+        id: node-cache
         with:
-          path: |
-            ~/.cache/ms-playwright
-            node_modules
-          key: ${{ runner.os }}-npm-v2-${{ hashFiles('**/package-lock.json') }}
+          path: node_modules
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
-            ${{ runner.os }}-npm-v2
+            ${{ runner.os }}-node-
+      - name: Cache Playwright Browsers
+        uses: actions/cache@v4
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
       - name: Install dependencies if cache invalid
-        if: steps.npm-cache.outputs.cache-hit != 'true'
+        if: steps.node-cache.outputs.cache-hit != 'true'
         run: npm ci
-      - name: Install Playwright browsers
+      - name: Install Playwright browsers if cache invalid
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: npx playwright install --with-deps
 
   # Run interaction and accessibility tests

--- a/.github/workflows/storybook-tests.yml
+++ b/.github/workflows/storybook-tests.yml
@@ -50,11 +50,6 @@ jobs:
             ${{ runner.os }}-node-
       - name: Install Playwright browsers
         run: npx playwright install --with-deps
-      - name: Update Node.js dependencies
-        run: |
-          npm update
-          echo "Updated packages:"
-          npm list --depth=0
       - name: Check for Storybook stories
         id: check-stories
         run: |
@@ -168,11 +163,6 @@ jobs:
             ${{ runner.os }}-node-
       - name: Install Playwright browsers
         run: npx playwright install --with-deps
-      - name: Update Node.js dependencies
-        run: |
-          npm update
-          echo "Updated packages:"
-          npm list --depth=0
       - name: Check for Storybook stories
         id: check-stories
         run: |

--- a/.github/workflows/storybook-tests.yml
+++ b/.github/workflows/storybook-tests.yml
@@ -51,16 +51,22 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Restore NPM dependencies
+      - name: Restore Node modules
         uses: actions/cache@v4
-        id: npm-cache
+        id: node-cache
         with:
-          path: |
-            ~/.cache/ms-playwright
-            node_modules
-          key: ${{ runner.os }}-npm-v2-${{ hashFiles('**/package-lock.json') }}
+          path: node_modules
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
-            ${{ runner.os }}-npm-v2
+            ${{ runner.os }}-node-
+      - name: Restore Playwright Browsers
+        uses: actions/cache@v4
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
       - name: Update Node.js dependencies
         run: |
           npm update
@@ -97,16 +103,22 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Restore NPM dependencies
+      - name: Restore Node modules
         uses: actions/cache@v4
-        id: npm-cache
+        id: node-cache
         with:
-          path: |
-            ~/.cache/ms-playwright
-            node_modules
-          key: ${{ runner.os }}-npm-v2-${{ hashFiles('**/package-lock.json') }}
+          path: node_modules
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
-            ${{ runner.os }}-npm-v2
+            ${{ runner.os }}-node-
+      - name: Restore Playwright Browsers
+        uses: actions/cache@v4
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
       - name: Check for Storybook stories
         id: check-stories
         run: |
@@ -134,16 +146,22 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Restore NPM dependencies
+      - name: Restore Node modules
         uses: actions/cache@v4
-        id: npm-cache
+        id: node-cache
         with:
-          path: |
-            ~/.cache/ms-playwright
-            node_modules
-          key: ${{ runner.os }}-npm-v2-${{ hashFiles('**/package-lock.json') }}
+          path: node_modules
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
-            ${{ runner.os }}-npm-v2
+            ${{ runner.os }}-node-
+      - name: Restore Playwright Browsers
+        uses: actions/cache@v4
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
       - name: Start the development server
         run: npm run dev &
       - name: Check for Playwright tests
@@ -169,16 +187,22 @@ jobs:
     steps:
       - name: Checkout Commit
         uses: actions/checkout@v4
-      - name: Restore NPM dependencies
+      - name: Restore Node modules
         uses: actions/cache@v4
-        id: npm-cache
+        id: node-cache
         with:
-          path: |
-            ~/.cache/ms-playwright
-            node_modules
-          key: ${{ runner.os }}-npm-v2-${{ hashFiles('**/package-lock.json') }}
+          path: node_modules
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
-            ${{ runner.os }}-npm-v2
+            ${{ runner.os }}-node-
+      - name: Restore Playwright Browsers
+        uses: actions/cache@v4
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
       - name: Update Node.js dependencies
         run: |
           npm update


### PR DESCRIPTION
## 연관 이슈

- Close #210

## 작업 요약

- 캐싱이 꼬여 스토리북 서버 실행 환경이 정상적으로 되지 않는 문제를 해결하였습니다.

## 작업 상세 설명

- <img width="400" alt="image" src="https://github.com/user-attachments/assets/61ff8b8b-458a-4966-9df8-fdeadfb4d3f5" />
   위 문제 해결하였습니다.
- 기존 캐싱이 nodemodule 관련 캐싱과, playwright(스토리북 서버) 관련 캐싱이 동시에 이루어졌는데, CI 환경에서 불완전한 복원이 발생할 가능성이 있어서 nodemodule만 캐싱하고, playwright(스토리북 서버) 캐싱은 필요한 곳에서 매번 설치 및 실행해주는 방식으로 변경하였습니다.
- npm update로 인한 패키지 버전 갱신으로 워크플로우 내 작업 간에 설치된 패키지 버전이 달라지지 않고 일관성을 유지할 수 있도록 처리해주었습니다.

## 리뷰 요구사항

- 2분
- <img width="369" alt="image" src="https://github.com/user-attachments/assets/a4936ec7-1313-483d-844d-96e8ecf95b75" /> 해당 문제는 #213 에서 해결하였습니다! 현재 PR에서는 실패 발생하는 게 정상입니다!
