### PR TITLE
다른 사용자의 마이페이지에 팔로우/언팔로우 버튼 구현

### DIFF
--- a/src/components/MyPage/FollowButton.tsx
+++ b/src/components/MyPage/FollowButton.tsx
@@ -1,0 +1,28 @@
+import { Button } from '@mui/material';
+import {
+  useCheckFollowStatusQuery,
+  useToggleFollowMutation,
+} from '@features/commons/followApi';
+
+interface FollowButtonProps {
+  userId: string;
+}
+
+const FollowButton = ({ userId }: FollowButtonProps) => {
+  const { data, isLoading } = useCheckFollowStatusQuery(userId);
+  const [toggleFollow, { isLoading: isToggling }] = useToggleFollowMutation();
+
+  if (isLoading) return <Button disabled>Loading...</Button>;
+
+  const handleClick = async () => {
+    await toggleFollow(userId);
+  };
+
+  return (
+    <Button onClick={handleClick} disabled={isToggling}>
+      {data?.isFollowing ? '팔로잉' : '팔로워'}
+    </Button>
+  );
+};
+
+export default FollowButton;

--- a/src/components/MyPage/UserInfoSection.tsx
+++ b/src/components/MyPage/UserInfoSection.tsx
@@ -1,5 +1,6 @@
 import { Stack, Typography, Avatar } from '@mui/material';
 import UserInfoSummary from './UserInfoSummary';
+import FollowButton from './FollowButton';
 import { UserInfo, UserStat } from './types';
 
 interface UserInfoSectionProps {
@@ -7,6 +8,8 @@ interface UserInfoSectionProps {
   userStats: UserStat[];
   userId: string;
   onRefetch: () => void;
+  showFollowButton: boolean;
+  userIdForFollow: string;
 }
 
 const UserInfoSection = ({
@@ -14,6 +17,8 @@ const UserInfoSection = ({
   userStats,
   userId,
   onRefetch,
+  showFollowButton,
+  userIdForFollow,
 }: UserInfoSectionProps): JSX.Element => {
   return (
     <Stack direction="row" alignItems="center" spacing={4} padding={4}>
@@ -23,9 +28,12 @@ const UserInfoSection = ({
         sx={{ width: 100, height: 100 }}
       />
       <Stack spacing={1}>
-        <Typography variant="h6" fontWeight="bold">
-          {userInfo.name}
-        </Typography>
+        <Stack direction="row" spacing={2} alignItems="center">
+          <Typography variant="h6" fontWeight="bold">
+            {userInfo.name}
+          </Typography>
+          {showFollowButton && <FollowButton userId={userIdForFollow} />}
+        </Stack>
         <Stack direction="row" spacing={2} alignItems="center">
           {userStats.map(({ count, label, isAction, type }) => (
             <UserInfoSummary

--- a/src/pages/MyPage/MyPage.tsx
+++ b/src/pages/MyPage/MyPage.tsx
@@ -67,8 +67,10 @@ const MyPage = (): JSX.Element => {
           about: data?.user_about,
         }}
         userStats={userStats}
-        userId={data?.user_id}
+        userId={data?.user_id.toString()}
         onRefetch={refetch}
+        showFollowButton={username !== currentUsername}
+        userIdForFollow={data?.user_id.toString()}
       />
       {/* TabSection props username으로 추후 교체 */}
       <TabSection userId={data?.user_id} username={username || ''} />


### PR DESCRIPTION
## 연관 이슈

> 연관된 이슈를 모두 기재 → #[Issue번호] 형식
- #222 
## 작업 요약

> 1~2줄 사이의 요약 설명

- 다른 사용자의 마이페이지에 팔로우/언팔로우 버튼을 구현
## 작업 상세 설명

> 주요 기능 및 로직에 대한 설명을 작성

- FollowButton컴포넌트를 생성하여 사용자의 팔로우 상태를 확인하고 토글하는 기능 제공
- followApi를 사용하여 팔로우 상태를 확인하고 버튼을 클릭하면 팔로우 상태 변경
## 리뷰 요구사항

> 리뷰 예상 시간 및 집중 리뷰 부분

리뷰 예상 시간: 5분
집중 리뷰 부분: 팔로우 상태 확인 및 토글 로직