### PR TITLE
팔로우 리스트에 팔로우 버튼 미표시 버그 해결

### DIFF
--- a/src/components/MyPage/FollowList.tsx
+++ b/src/components/MyPage/FollowList.tsx
@@ -144,11 +144,11 @@ const FollowList = ({ setOpen, type, userId, onRefetch }: FollowListProps) => {
                 primary={username}
                 onClick={() => handleUserClick(username)}
               />
-              {currentUserId !== userId && (
+              {currentUserId !== id && (
                 <Button
                   variant="contained"
                   size="small"
-                  onClick={() => handleToggleFollow(userId)}
+                  onClick={() => handleToggleFollow(id)}
                 >
                   {isFollowing ? '언팔로우' : '팔로우'}
                 </Button>


### PR DESCRIPTION
## 연관 이슈

- #225

## 작업 요약

- 팔로우 버튼 표시 로직 변경

## 작업 상세 설명
```
{currentUserId !== userId && (
    <Button
      variant="contained"
      size="small"
      onClick={() => handleToggleFollow(userId)}
    >
      {isFollowing ? '언팔로우' : '팔로우'}
    </Button>
  )}
```
```currentUserId (접속중인 유저의 id)```와 ```userId (현재 위치한 유저 페이지의 userId)``` 가 다를 때 표시가 아니라 팔로우 리스트의 각각의 유저 id가 다를 때 표시해야 함.

> ```userId => id``` 로 변경

## 리뷰 요구사항

- 1분
