### PR TITLE
마이페이지 UI 수정

### DIFF
--- a/src/components/MyPage/Feed/OneLineReviewSection.tsx
+++ b/src/components/MyPage/Feed/OneLineReviewSection.tsx
@@ -49,25 +49,33 @@ const OneLineReviewSection = ({
           더보기
         </Button>
       </Box>
-      <Grid container spacing={2}>
-        {oneLineReviews.map((oneLineReview, index) => (
-          <Grid
-            key={index}
-            size={{ xs: 12, md: 4 }}
-            sx={{ display: 'flex', flexDirection: 'column' }}
-          >
-            <ReviewCard
-              postId={oneLineReview.postId}
-              rating={oneLineReview.rating ?? 0}
-              username={oneLineReview.user.username}
-              avatarUrl={oneLineReview.user.avatarUrl ?? ''}
-              date={formatDate(oneLineReview.createdAt)}
-              content={oneLineReview.review}
-              isbn={oneLineReview.book.isbn}
-            />
-          </Grid>
-        ))}
-      </Grid>
+      {oneLineReviews.length === 0 ? (
+        <Typography variant="body1" sx={{ textAlign: 'center', py: 4 }}>
+          {type === '내 피드'
+            ? '작성한 한줄평이 없습니다.'
+            : '한줄평에 좋아요를 누른 항목이 없습니다.'}
+        </Typography>
+      ) : (
+        <Grid container spacing={2}>
+          {oneLineReviews.map((oneLineReview, index) => (
+            <Grid
+              key={index}
+              size={{ xs: 12, md: 4 }}
+              sx={{ display: 'flex', flexDirection: 'column' }}
+            >
+              <ReviewCard
+                postId={oneLineReview.postId}
+                rating={oneLineReview.rating ?? 0}
+                username={oneLineReview.user.username}
+                avatarUrl={oneLineReview.user.avatarUrl ?? ''}
+                date={formatDate(oneLineReview.createdAt)}
+                content={oneLineReview.review}
+                isbn={oneLineReview.book.isbn}
+              />
+            </Grid>
+          ))}
+        </Grid>
+      )}
     </Box>
   );
 };

--- a/src/components/MyPage/Feed/PostingSection.tsx
+++ b/src/components/MyPage/Feed/PostingSection.tsx
@@ -48,23 +48,31 @@ const PostingFeedSection = ({
           더보기
         </Button>
       </Box>
-      <Grid container spacing={2}>
-        {postings.map((posting, index) => (
-          <Grid
-            key={index}
-            size={{ xs: 12, md: 4 }}
-            sx={{ display: 'flex', flexDirection: 'column' }}
-          >
-            <PostCard
-              postId={posting.postId}
-              title={posting.title}
-              content={posting.content}
-              isbn={posting.book.isbn}
-              user={posting.user}
-            />
-          </Grid>
-        ))}
-      </Grid>
+      {postings.length === 0 ? (
+        <Typography variant="body1" sx={{ textAlign: 'center', py: 4 }}>
+          {type === '내 피드'
+            ? '작성한 포스팅이 없습니다.'
+            : '포스팅에 좋아요를 누른 항목이 없습니다.'}
+        </Typography>
+      ) : (
+        <Grid container spacing={2}>
+          {postings.map((posting, index) => (
+            <Grid
+              key={index}
+              size={{ xs: 12, md: 4 }}
+              sx={{ display: 'flex', flexDirection: 'column' }}
+            >
+              <PostCard
+                postId={posting.postId}
+                title={posting.title}
+                content={posting.content}
+                isbn={posting.book.isbn}
+                user={posting.user}
+              />
+            </Grid>
+          ))}
+        </Grid>
+      )}
     </Box>
   );
 };

--- a/src/components/MyPage/Library/BookshelfCard.tsx
+++ b/src/components/MyPage/Library/BookshelfCard.tsx
@@ -3,7 +3,7 @@ import {
   Card,
   CardActionArea,
   CardContent,
-  Grid2,
+  Grid,
   Typography,
   useMediaQuery,
   useTheme,
@@ -28,21 +28,49 @@ const BookshelfCard = ({ shelf, username }: BookshelfCardProps) => {
   return (
     <Card
       sx={{
-        maxWidth: sm ? 200 : '100%',
+        width: sm ? 200 : '100%',
+        maxWidth: 200,
       }}
     >
       <CardActionArea onClick={handleClick}>
-        <Grid2 container height={140} overflow="hidden">
-          {shelf.books.map((book) => (
-            <Grid2
-              key={`${book.isbn}-${shelf.id}`}
-              size={shelf.books.length === 1 ? 12 : 6}
-              height={shelf.books.length > 2 ? '50%' : '100%'}
+        <Grid
+          container
+          height={140}
+          overflow="hidden"
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}
+        >
+          {shelf.books.length > 0 ? (
+            shelf.books.map((book) => (
+              <Grid
+                item
+                key={`${book.isbn}-${shelf.id}`}
+                xs={shelf.books.length === 1 ? 12 : 6}
+                sx={{ height: shelf.books.length > 2 ? '50%' : '100%' }}
+              >
+                <BookShelfThumbnail isbn={book.isbn} />
+              </Grid>
+            ))
+          ) : (
+            <Grid
+              item
+              xs={12}
+              sx={{
+                height: '100%',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+              }}
             >
-              <BookShelfThumbnail isbn={book.isbn} />
-            </Grid2>
-          ))}
-        </Grid2>
+              <Typography variant="body2" color="text.secondary">
+                책이 없습니다
+              </Typography>
+            </Grid>
+          )}
+        </Grid>
         <CardContent>
           <Typography gutterBottom>{shelf.name}</Typography>
           <Typography variant="body2" color="text.secondary">


### PR DESCRIPTION
## 연관 이슈

> 연관된 이슈를 모두 기재 → #[Issue번호] 형식
- #232 
## 작업 요약

> 1~2줄 사이의 요약 설명
- 내 피드와 좋아요한 피드에서 한줄평 및 포스팅이 없을 때 표시할 메시지 추가
- 빈 책장 카드의 크기를 조정
- 빈 책장에 "책이 없습니다" 메시지 추가
## 작업 상세 설명

> 주요 기능 및 로직에 대한 설명을 작성
- **내 피드**: "작성한 한줄평이 없습니다"와 "작성한 포스팅이 없습니다" 메시지 추가
- **좋아요한 피드**: "한줄평에 좋아요를 누른 항목이 없습니다"와 "포스팅에 좋아요를 누른 항목이 없습니다." 메시지 추가
- 빈 책장 카드의 너비를 고정하여 책이 있는 경우와 없는 경우의 크기를 일관되게 유지하도록 수정
- 책이 없는 경우 "책이 없습니다"라는 메시지를 가운데 정렬하여 표시하도록 구현
## 리뷰 요구사항

> 리뷰 예상 시간 및 집중 리뷰 부분

리뷰 예상 시간: 10분
집중 리뷰 부분: Grid 컴포넌트 사용 -> Grid2 사용시 타입스크립트 오류 발생해서 Gird로 변경했습니다
                       메시지의 문구와 레이아웃 확인
## Preview 이미지 (필요시)
### 마이페이지 내 서재 빈 서재일 때
<img width="1510" alt="스크린샷 2025-02-16 오후 3 37 52" src="https://github.com/user-attachments/assets/aa91454c-cf42-4e98-9706-42d1676080de" />

### 내 피드
<img width="1500" alt="스크린샷 2025-02-16 오후 3 38 02" src="https://github.com/user-attachments/assets/9c04e3d2-7876-4ec8-b6cf-8e2e3715c971" />

### 좋아요 한 피드
<img width="1509" alt="스크린샷 2025-02-16 오후 3 38 10" src="https://github.com/user-attachments/assets/ec8bff38-85cf-4939-bae4-78dfc2c202a3" />
