### PR TITLE
아이디 및 나이 유효성 강화 및 닉네임 길이 제한 추가

### DIFF
--- a/src/pages/EditAccountPage.tsx/EditAccountPage.tsx
+++ b/src/pages/EditAccountPage.tsx/EditAccountPage.tsx
@@ -49,6 +49,19 @@ const EditAccountPage = (): JSX.Element => {
         ) as HTMLInputElement
       )?.value;
 
+      if (
+        fieldName === 'username' &&
+        (newValue.length < 2 || newValue.length > 10)
+      ) {
+        dispatch(
+          showSnackbar({
+            message: '닉네임은 최소 2자에서 최대 10자까지 가능합니다.',
+            severity: 'error',
+          }),
+        );
+        return;
+      }
+
       const result = await updateField({
         userId,
         fieldName,
@@ -213,6 +226,7 @@ const EditAccountPage = (): JSX.Element => {
             label="닉네임"
             name="username"
             defaultValue={data.username || ''}
+            inputProps={{ maxLength: 20 }}
           />
           <Button variant="contained" onClick={() => handleSubmit('username')}>
             변경

--- a/src/utils/SignupPage/yupSchema.ts
+++ b/src/utils/SignupPage/yupSchema.ts
@@ -6,7 +6,12 @@ export const signupSchema = yup.object<SignupData>().shape({
   userId: yup
     .string()
     .required('아이디를 입력해주세요')
-    .min(4, '아이디는 최소 4자 이상이어야 합니다'),
+    .min(4, '아이디는 최소 4자 이상이어야 합니다')
+    .max(20, '아이디는 최대 20자까지 가능합니다')
+    .matches(
+      /^[a-zA-Z0-9_]+$/,
+      '아이디는 영문, 숫자, 언더스코어(_)만 사용 가능합니다',
+    ),
   email: yup
     .string()
     .required('이메일을 입력해주세요')
@@ -30,11 +35,26 @@ export const signupSchema = yup.object<SignupData>().shape({
     .matches(
       /^\d{4}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])$/,
       '올바른 날짜 형식이 아닙니다',
-    ),
+    )
+    .test('is-valid-age', '유효하지 않은 생년월일입니다', function (value) {
+      if (!value) return false;
+      const birthDate = new Date(value);
+      const today = new Date();
+      const age = today.getFullYear() - birthDate.getFullYear();
+      return age >= 14 && age <= 120;
+    }),
 });
 
 export const additionalInfoSchema = yup.object().shape({
-  userId: yup.string().required('아이디는 필수입니다'),
+  userId: yup
+    .string()
+    .required('아이디는 필수입니다')
+    .min(4, '아이디는 최소 4자 이상이어야 합니다')
+    .max(20, '아이디는 최대 20자까지 가능합니다')
+    .matches(
+      /^[a-zA-Z0-9_]+$/,
+      '아이디는 영문, 숫자, 언더스코어(_)만 사용 가능합니다',
+    ),
   gender: yup.string().required('성별을 선택해주세요'),
   birthDate: yup
     .string()
@@ -42,5 +62,12 @@ export const additionalInfoSchema = yup.object().shape({
     .matches(
       /^\d{4}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])$/,
       '올바른 날짜 형식이 아닙니다',
-    ),
+    )
+    .test('is-valid-age', '유효하지 않은 생년월일입니다', function (value) {
+      if (!value) return false;
+      const birthDate = new Date(value);
+      const today = new Date();
+      const age = today.getFullYear() - birthDate.getFullYear();
+      return age >= 14 && age <= 120;
+    }),
 });


### PR DESCRIPTION
## 연관 이슈

> 연관된 이슈를 모두 기재 → #[Issue번호] 형식
- #227
## 작업 요약

> 1~2줄 사이의 요약 설명

아이디와 나이의 유효성을 강화하고, 닉네임 필드에 길이 제한 추가
## 작업 상세 설명

> 주요 기능 및 로직에 대한 설명을 작성

- **아이디 필드 제한**: 최소 4자에서 최대 20자로 제한하고, 영문, 숫자, 언더스코어(_)만 사용 가능하도록 추가

- **나이 필드 제한**: 사용자의 나이가 14세 이상 120세 이하로 제한

- **닉네임 필드 제한**: 닉네임이 최소 2자에서 최대 20자 사이인지 확인하는 유효성 검사 추가

- additionalInfoSchema에도 동일한 제한 적용


## 리뷰 요구사항

> 리뷰 예상 시간 및 집중 리뷰 부분

리뷰 예상 시간: 15분
집중 리뷰 부분: 아이디 및 나이의 유효성 검사 로직과 닉네임 길이 제한