### PR TITLE
Props 관련 오류 수정

### DIFF
--- a/src/components/PostingWritePage/BookSearchPopover.tsx
+++ b/src/components/PostingWritePage/BookSearchPopover.tsx
@@ -6,16 +6,12 @@ import { Book } from '@shared/types/type';
 export interface BookSearchPopoverProps {
   anchorEl: HTMLElement | null;
   onClose: () => void;
-  searchQuery: string;
-  setSearchQuery: (query: string) => void;
   selectedBook: Book | null;
   setSelectedBook: (book: Book | null) => void;
 }
 const BookSearchPopover = ({
   anchorEl,
   onClose,
-  searchQuery,
-  setSearchQuery,
   selectedBook,
   setSelectedBook,
 }: BookSearchPopoverProps) => (
@@ -34,8 +30,6 @@ const BookSearchPopover = ({
   >
     <Box sx={postingWriteStyles.bookSearchBox}>
       <BookSearchAutoComplete
-        searchQuery={searchQuery}
-        setSearchQuery={setSearchQuery}
         selectedBook={selectedBook}
         setSelectedBook={setSelectedBook}
       />

--- a/src/components/PostingWritePage/PostingWrite.tsx
+++ b/src/components/PostingWritePage/PostingWrite.tsx
@@ -20,7 +20,6 @@ const PostingWrite = () => {
   const isEditing = location.pathname.includes('/posting/edit');
   // 상세페이지에서 포스팅 작성 누를 시 책 정보 가져옴
   const bookFromDetail = location.state?.book as Book;
-  const [searchQuery, setSearchQuery] = useState('');
   const [selectedBook, setSelectedBook] = useState<Book | null>(
     bookFromDetail || null,
   );
@@ -111,8 +110,6 @@ const PostingWrite = () => {
         <BookSearchPopover
           anchorEl={anchorEl}
           onClose={handleClose}
-          searchQuery={searchQuery}
-          setSearchQuery={setSearchQuery}
           selectedBook={selectedBook}
           setSelectedBook={setSelectedBook}
         />


### PR DESCRIPTION
## 연관 이슈

- #239 

## 작업 요약

> 1~2줄 사이의 요약 설명

- BookSearchPopover.tsx 파일에서 BookSearchAutoComplete 로 props 넘길 때
searchQuery, setSearchQuery 값을 props주는데 BookSearchAutoComplete는 이 2개의 props를 받지 않아서 오류 발생하였음.
- searchQuery 값을 가장 자식컴포넌트가 useState로 상태 관리 되고 있는 거 같아서 전 부모컴포넌트들에게 props로 받고 있어서 그 값들을 모두 삭제 하였습니다.

## 리뷰 요구사항

- @deenuit113 혹시 이렇게 고쳐도 맞는건지 확인해주시면 감사하겠습니다.
- 이부분이 포스팅작성페이지에 책 검색하는 부분이 맞는지? 궁금합니다. 고치고나서 검색 작동 잘 되는지 확인 하였습니다.

## Preview 이미지 (필요시)
