### PR TITLE
피드 페이지 cls 개선

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "@emotion/styled": "^11.14.0",
         "@hookform/resolvers": "^3.9.1",
         "@mui/icons-material": "^6.2.1",
-        "@mui/lab": "^6.0.0-beta.20",
         "@mui/material": "^6.2.0",
         "@mui/x-date-pickers": "^7.26.0",
         "@reduxjs/toolkit": "^2.5.0",
@@ -1437,44 +1436,6 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
-    "node_modules/@floating-ui/core": {
-      "version": "1.6.8",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.8.tgz",
-      "integrity": "sha512-7XJ9cPU+yI2QeLS+FCSlqNFZJq8arvswefkZrYI1yQBbftw6FyrZOxYSh+9S7z7TpeWlRt9zJ5IhM1WIL334jA==",
-      "license": "MIT",
-      "dependencies": {
-        "@floating-ui/utils": "^0.2.8"
-      }
-    },
-    "node_modules/@floating-ui/dom": {
-      "version": "1.6.12",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.12.tgz",
-      "integrity": "sha512-NP83c0HjokcGVEMeoStg317VD9W7eDlGK7457dMBANbKA6GJZdc7rjujdgqzTaz93jkGgc5P/jeWbaCHnMNc+w==",
-      "license": "MIT",
-      "dependencies": {
-        "@floating-ui/core": "^1.6.0",
-        "@floating-ui/utils": "^0.2.8"
-      }
-    },
-    "node_modules/@floating-ui/react-dom": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.2.tgz",
-      "integrity": "sha512-06okr5cgPzMNBy+Ycse2A6udMi4bqwW/zgBF/rwjcNqWkyr82Mcg8b0vjX8OJpZFy/FKjJmw6wV7t44kK6kW7A==",
-      "license": "MIT",
-      "dependencies": {
-        "@floating-ui/dom": "^1.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0"
-      }
-    },
-    "node_modules/@floating-ui/utils": {
-      "version": "0.2.8",
-      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.8.tgz",
-      "integrity": "sha512-kym7SodPp8/wloecOpcmSnWJsK7M0E5Wg8UcFA+uO4B9s5d0ywXOEro/8HM9x0rW+TljRzul/14UYz3TleT3ig==",
-      "license": "MIT"
-    },
     "node_modules/@hapi/hoek": {
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
@@ -2275,38 +2236,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/@mui/base": {
-      "version": "5.0.0-beta.68",
-      "resolved": "https://registry.npmjs.org/@mui/base/-/base-5.0.0-beta.68.tgz",
-      "integrity": "sha512-F1JMNeLS9Qhjj3wN86JUQYBtJoXyQvknxlzwNl6eS0ZABo1MiohMONj3/WQzYPSXIKC2bS/ZbyBzdHhi2GnEpA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.26.0",
-        "@floating-ui/react-dom": "^2.1.1",
-        "@mui/types": "^7.2.20",
-        "@mui/utils": "^6.3.0",
-        "@popperjs/core": "^2.11.8",
-        "clsx": "^2.1.1",
-        "prop-types": "^15.8.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui-org"
-      },
-      "peerDependencies": {
-        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@mui/core-downloads-tracker": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-6.3.1.tgz",
@@ -2338,51 +2267,6 @@
         "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
       },
       "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@mui/lab": {
-      "version": "6.0.0-beta.22",
-      "resolved": "https://registry.npmjs.org/@mui/lab/-/lab-6.0.0-beta.22.tgz",
-      "integrity": "sha512-9nwUfBj+UzoQJOCbqV+JcCSJ74T+gGWrM1FMlXzkahtYUcMN+5Zmh2ArlttW3zv2dZyCzp7K5askcnKF0WzFQg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.26.0",
-        "@mui/base": "5.0.0-beta.68",
-        "@mui/system": "^6.3.1",
-        "@mui/types": "^7.2.21",
-        "@mui/utils": "^6.3.1",
-        "clsx": "^2.1.1",
-        "prop-types": "^15.8.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui-org"
-      },
-      "peerDependencies": {
-        "@emotion/react": "^11.5.0",
-        "@emotion/styled": "^11.3.0",
-        "@mui/material": "^6.3.1",
-        "@mui/material-pigment-css": "^6.3.1",
-        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@emotion/react": {
-          "optional": true
-        },
-        "@emotion/styled": {
-          "optional": true
-        },
-        "@mui/material-pigment-css": {
-          "optional": true
-        },
         "@types/react": {
           "optional": true
         }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "@emotion/styled": "^11.14.0",
     "@hookform/resolvers": "^3.9.1",
     "@mui/icons-material": "^6.2.1",
-    "@mui/lab": "^6.0.0-beta.20",
     "@mui/material": "^6.2.0",
     "@mui/x-date-pickers": "^7.26.0",
     "@reduxjs/toolkit": "^2.5.0",

--- a/src/components/FeedPage/PostCard/PostCard.styles.ts
+++ b/src/components/FeedPage/PostCard/PostCard.styles.ts
@@ -5,7 +5,6 @@ const styles = {
     flexDirection: 'column',
     boxSizing: 'border-box',
     width: '100%',
-    aspectRatio: 'auto',
     borderRadius: '8px',
     transition: 'all 0.3s ease-in-out',
     '&:hover': {
@@ -37,7 +36,6 @@ const styles = {
         ? theme.palette.primary.light
         : theme.palette.primary.main,
     border: 'none',
-    mb: '0',
     '&:hover': {
       backgroundColor: isFollowing
         ? theme.palette.mode === 'light'
@@ -135,7 +133,7 @@ const styles = {
     whiteSpace: 'pre-wrap',
   },
   postingDescription: {
-    height: 'auto',
+    height: '120px',
     padding: '0.25rem 0.5rem',
     textOverflow: 'ellipsis',
     overflow: 'hidden',

--- a/src/components/FeedPage/PostCard/PostCard.styles.ts
+++ b/src/components/FeedPage/PostCard/PostCard.styles.ts
@@ -14,7 +14,6 @@ const styles = {
   },
   cardHeader: {
     display: 'flex',
-    height: '10%',
     flexDirection: 'row',
     justifyContent: 'space-between',
     alignItems: 'center',
@@ -53,7 +52,6 @@ const styles = {
   },
   cardMediaBox: {
     position: 'relative',
-    height: '60%',
     width: '100%',
     overflow: 'hidden',
     boxSizing: 'border-box',
@@ -90,7 +88,6 @@ const styles = {
     width: '100%',
     maxWidth: '100%',
     padding: '1rem 1rem 0.5rem 1rem',
-    height: '20%',
     borderRadius: '10px 10px 10px 0px',
     position: 'relative',
     zIndex: 2,
@@ -145,7 +142,6 @@ const styles = {
   },
   cardFooter: {
     padding: '0',
-    height: '10%',
     borderTop: '1px solid #ddd',
     gap: 0,
     display: 'grid',

--- a/src/components/FeedPage/PostCard/PostCard.tsx
+++ b/src/components/FeedPage/PostCard/PostCard.tsx
@@ -8,6 +8,7 @@ import PostCardFooter from './PostCardFooter';
 import { navigateToPostingDetailPage } from '@shared/utils/navigation';
 import { useNavigate } from 'react-router-dom';
 import { useSearchBookByIsbnQuery } from '@features/commons/bookSearchByIsbn';
+import PostCardSkeleton from './PostCardSkeleton';
 
 interface PostCardBaseProps {
   postId: string;
@@ -64,7 +65,7 @@ const PostCard = ({
     }
   };
 
-  if (isLoading) return <div>Loading book information...</div>;
+  if (isLoading) return <PostCardSkeleton postType={postType} />;
   if (error) return <div>Error fetching book information</div>;
 
   return (

--- a/src/components/FeedPage/PostCard/PostCardSkeleton.tsx
+++ b/src/components/FeedPage/PostCard/PostCardSkeleton.tsx
@@ -15,12 +15,7 @@ const PostCardSkeleton = ({ postType }: PostCardSkeletonProps) => {
         title={<Skeleton height={10} width="80%" style={{ marginBottom: 6 }} />}
         subheader={<Skeleton animation="wave" height={10} width="40%" />}
       />
-      <Skeleton
-        variant="rectangular"
-        width="100%"
-        height={220}
-        sx={{ mb: 1 }}
-      />
+      <Skeleton variant="rectangular" width="100%" height={210} />
       <Box padding={2}>
         <Skeleton width="60%" />
         <Skeleton width="90%" />
@@ -33,7 +28,7 @@ const PostCardSkeleton = ({ postType }: PostCardSkeletonProps) => {
           </>
         )}
       </Box>
-      <Skeleton sx={{ bgcolor: 'grey.50' }} variant="rectangular" height={48} />
+      <Skeleton sx={{ bgcolor: 'grey.50' }} variant="rectangular" height={50} />
     </Card>
   );
 };

--- a/src/components/FeedPage/PostCard/PostCardSkeleton.tsx
+++ b/src/components/FeedPage/PostCard/PostCardSkeleton.tsx
@@ -1,0 +1,41 @@
+import { Card, Skeleton, Box, CardHeader } from '@mui/material';
+import styles from './PostCard.styles';
+import { PostType } from '@shared/types/type';
+
+interface PostCardSkeletonProps {
+  postType: PostType;
+}
+
+const PostCardSkeleton = ({ postType }: PostCardSkeletonProps) => {
+  return (
+    <Card sx={styles.card}>
+      <CardHeader
+        sx={styles.cardHeader}
+        avatar={<Skeleton variant="circular" width={40} height={40} />}
+        title={<Skeleton height={10} width="80%" style={{ marginBottom: 6 }} />}
+        subheader={<Skeleton animation="wave" height={10} width="40%" />}
+      />
+      <Skeleton
+        variant="rectangular"
+        width="100%"
+        height={220}
+        sx={{ mb: 1 }}
+      />
+      <Box padding={2}>
+        <Skeleton width="60%" />
+        <Skeleton width="90%" />
+        <Skeleton width="70%" />
+        <Skeleton width="60%" />
+        {postType === '포스팅' && (
+          <>
+            <Skeleton width="30%" />
+            <Skeleton width="60%" />
+          </>
+        )}
+      </Box>
+      <Skeleton sx={{ bgcolor: 'grey.50' }} variant="rectangular" height={48} />
+    </Card>
+  );
+};
+
+export default PostCardSkeleton;

--- a/src/components/FeedPage/PostCard/PostCardSkeleton.tsx
+++ b/src/components/FeedPage/PostCard/PostCardSkeleton.tsx
@@ -15,7 +15,13 @@ const PostCardSkeleton = ({ postType }: PostCardSkeletonProps) => {
         title={<Skeleton height={10} width="80%" style={{ marginBottom: 6 }} />}
         subheader={<Skeleton animation="wave" height={10} width="40%" />}
       />
-      <Skeleton variant="rectangular" width="100%" height={210} />
+      <Skeleton
+        variant="rectangular"
+        width="100%"
+        sx={{
+          height: { xs: 410, sm: 310, md: 275, lg: 210 },
+        }}
+      />
       <Box padding={2}>
         <Skeleton width="60%" />
         <Skeleton width="90%" />

--- a/src/hooks/useColumnCount.ts
+++ b/src/hooks/useColumnCount.ts
@@ -1,0 +1,18 @@
+import { useMemo } from 'react';
+import { useMediaQuery, useTheme } from '@mui/material';
+
+const useColumnCount = () => {
+  const theme = useTheme();
+  const isXs = useMediaQuery(theme.breakpoints.down('sm'));
+  const isSm = useMediaQuery(theme.breakpoints.between('sm', 'md'));
+  const isMd = useMediaQuery(theme.breakpoints.between('md', 'lg'));
+
+  return useMemo(() => {
+    if (isXs) return 1;
+    if (isSm) return 2;
+    if (isMd) return 3;
+    return 4;
+  }, [isXs, isSm, isMd]);
+};
+
+export default useColumnCount;

--- a/src/pages/MainPage/Main.tsx
+++ b/src/pages/MainPage/Main.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 import {
   Box,
   CircularProgress,
@@ -6,7 +6,6 @@ import {
   Divider,
   Stack,
 } from '@mui/material';
-import Masonry from '@mui/lab/Masonry';
 import InfiniteScroll from 'react-infinite-scroll-component';
 import PostCard from '@components/FeedPage/PostCard/PostCard';
 import ScrollToTop from '@components/commons/ScrollToTop';
@@ -25,6 +24,7 @@ import {
   setTotalCount,
 } from '@features/FeedPage/slice/feedSlice';
 import WriteButton from '@components/FeedPage/WriteButton';
+import useColumnCount from '@hooks/useColumnCount';
 
 const Main = (): JSX.Element => {
   const dispatch = useDispatch();
@@ -39,6 +39,20 @@ const Main = (): JSX.Element => {
     { page, postType, feedType },
     { refetchOnMountOrArgChange: true },
   );
+
+  const columnCount = useColumnCount();
+  const columns = useMemo(() => {
+    const cols: (OneLinePost | Posting)[][] = Array.from(
+      { length: columnCount },
+      () => [],
+    );
+    if (data?.posts) {
+      data.posts.forEach((post, index) => {
+        cols[index % columnCount].push(post);
+      });
+    }
+    return cols;
+  }, [data?.posts, columnCount]);
 
   useEffect(() => {
     if (data) {
@@ -138,19 +152,7 @@ const Main = (): JSX.Element => {
         next={fetchMoreData}
         hasMore={data?.hasMore ?? false}
         scrollThreshold={0.99}
-        loader={
-          <Box
-            sx={{
-              width: '100%',
-              display: 'flex',
-              justifyContent: 'center',
-              alignItems: 'center',
-              padding: '2rem 1rem',
-            }}
-          >
-            <CircularProgress />
-          </Box>
-        }
+        loader={<></>}
         endMessage={
           <Box
             sx={{
@@ -165,7 +167,7 @@ const Main = (): JSX.Element => {
           </Box>
         }
         style={{
-          padding: '20px 0',
+          padding: '0',
           boxSizing: 'border-box',
           display: 'flex',
           flexDirection: 'column',
@@ -174,52 +176,40 @@ const Main = (): JSX.Element => {
           overflowX: 'hidden',
         }}
       >
-        {isLoading || !data ? (
-          <Box sx={{ display: 'flex', justifyContent: 'center', p: 2 }}>
-            <CircularProgress />
-          </Box>
-        ) : (
-          <Masonry
-            columns={{ xs: 1, sm: 2, md: 3, lg: 4 }}
-            spacing={4}
-            sx={{
-              width: '100%',
-              boxSizing: 'border-box',
-              overflowX: 'hidden',
-            }}
-          >
-            {data?.posts?.map((post: OneLinePost | Posting) => {
-              if ('title' in post && 'content' in post) {
-                return (
-                  <Box key={post.id}>
-                    <PostCard
-                      postId={post.id}
-                      createdAt={post.createdAt}
-                      user={post.user}
-                      book={post.book}
-                      postType={post.postType}
-                      title={post.title}
-                      content={post.content}
-                    />
-                  </Box>
-                );
-              } else {
-                return (
-                  <Box key={post.id}>
-                    <PostCard
-                      postId={post.id}
-                      createdAt={post.createdAt}
-                      user={post.user}
-                      book={post.book}
-                      postType={post.postType}
-                      review={post.review}
-                    />
-                  </Box>
-                );
-              }
-            })}
-          </Masonry>
-        )}
+        <Box sx={{ display: 'flex', width: '100%' }}>
+          {columns.map((col, colIndex) => (
+            <Box
+              key={colIndex}
+              sx={{
+                display: 'flex',
+                flexDirection: 'column',
+                margin: 2,
+                gap: 4,
+                flex: 1,
+              }}
+            >
+              {col.map((post: OneLinePost | Posting) => (
+                <PostCard
+                  key={post.id}
+                  postId={post.id}
+                  createdAt={post.createdAt}
+                  user={post.user}
+                  book={post.book}
+                  {...('title' in post
+                    ? {
+                        title: post.title,
+                        content: post.content,
+                        postType: '포스팅',
+                      }
+                    : {
+                        review: post.review,
+                        postType: '한줄평',
+                      })}
+                />
+              ))}
+            </Box>
+          ))}
+        </Box>
       </InfiniteScroll>
       <ScrollToTop />
     </Container>


### PR DESCRIPTION
## 연관 이슈

- Close #242

## 작업 요약

- 피드 페이지 CLS 수치 `1.011`(최신 develop 브랜치 커밋 ba765892a67d9268e9c761cd5e394851ba47ff89 기준) -> `0.001`으로 개선하였습니다.

## 작업 상세 설명

- MUI Masonry 대신 **flex와 js로 동적 column을 사용하는 방식**으로 변경하였습니다.
  - 기존에 사용하던 MUI Masonry 컴포넌트의 경우, 1개의 column으로 렌더링 후 설정한 column 수로 펼쳐지는 형태로 성능이 저하되는 문제가 있어 이를 대체하며 성능을 개선하였습니다.
- PostCard에 **스켈레톤을 적용**하여 비동기 데이터로 새로 추가되는 영역에 대해 미리 공간 확보하여 성능을 개선하였습니다.
- PostCard를 포스트, 한줄평 각각의 **크기를 고정**하여, 스켈레톤과 크기를 맞춰주며 layout shift를 방지하였습니다.
  - 기존 PostCard는 content 길이에 따라 유동적으로 변하는 스타일이었지만, 성능상 이점을 좀 더 취하기 위해 고정 크기로 변경하였습니다.

<img width="300" alt="image" src="https://github.com/user-attachments/assets/2825e7fa-224e-4eba-822e-dd62b9a0b7ca" />

위의 사항들을 적용 후 위험 수치였던 `1.011`에서 안전 수치인 `0.001`으로 개선되었습니다.
(측정 시마다 수치에 조금씩 변동은 있지만, 위험 수치냐, 안전 수치냐의 여부에 있어서는 항상 동일하게 측정되었습니다.)


+)
- Masonry 컴포넌트 사용하지 않음에 따라, mui lab 라이브러리도 삭제하였습니다.
- 스켈레톤 반응형에 따라서도 확인 후 처리하였습니다.

## 리뷰 요구사항

예상 리뷰 시간 10분

## Preview

https://github.com/user-attachments/assets/3ee98a63-f084-473c-bd8c-fb4b8c794883

