### PR TITLE
포스팅 상세 페이지 레이아웃 깨짐 현상 해결

### DIFF
--- a/src/components/PostingDetailPage/PostingDetail.styles.ts
+++ b/src/components/PostingDetailPage/PostingDetail.styles.ts
@@ -2,11 +2,6 @@ import { Theme } from '@mui/material';
 
 export const postingDetailStyles = {
   container: {
-    display: 'flex',
-    flexDirection: 'column',
-    justifyContent: 'flex-start',
-    alignItems: 'center',
-    minHeight: '100vh',
     width: '100%',
     padding: '0 !important',
     margin: '0 !important',

--- a/src/pages/PostingDetailPage/PostingDetailPage.tsx
+++ b/src/pages/PostingDetailPage/PostingDetailPage.tsx
@@ -35,8 +35,11 @@ const PostingDetailPage = () => {
       maxWidth={false}
       sx={{
         ...postingDetailStyles.container,
+        minHeight: '100vh',
         display: 'flex',
-        justifyContent: 'flex-end',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'flex-start',
       }}
     >
       <PostingHeader


### PR DESCRIPTION
포스팅 상세페이지 컨테이너 CSS 우선순위 변경
스타일 파일 > 컴포넌트
Resolves: #249

## 연관 이슈

- #249 

## 작업 요약

- 포스팅 상세페이지 레이아웃 관련 CSS 코드 위치 옮김

## 작업 상세 설명

- 컨테이너 컴포넌트의 레이아웃 관련 CSS가 스타일 파일에 작성되었을 때는 우선순위가 낮아 MUI 기본 CSS와 충돌하는 것 같음. 
- 컴포넌트에 직접 작성
- 추후 MUI CSS Reset 필요
- 참고자료: - [MUI 공식문서](https://mui.com/material-ui/react-css-baseline/?srsltid=AfmBOoo1sjzLtvghBwEpx5i-3PyYezb7VCxSiato-eXpdgXscCarAYdd)

## 리뷰 요구사항

- 리뷰 예상 시간: 1분

## Preview 이미지 (필요시)
![Image](https://github.com/user-attachments/assets/43cbc798-a927-4539-9508-1d4be8099546)

![image](https://github.com/user-attachments/assets/1345b34d-7656-4f5a-b285-582ba66d6aa6)

