### PR TITLE
피드페이지 좋아요 버튼 로직 수정

### DIFF
--- a/src/components/FeedPage/PostCard/PostCardFooter.tsx
+++ b/src/components/FeedPage/PostCard/PostCardFooter.tsx
@@ -11,6 +11,7 @@ import {
 } from '@features/commons/likeApi';
 import { useSelector } from 'react-redux';
 import { RootState } from '@store/index';
+import { useEffect } from 'react';
 
 interface PostCardFooterProps {
   postId: string;
@@ -23,6 +24,13 @@ const PostCardFooter = ({ postId, isbn }: PostCardFooterProps): JSX.Element => {
   const isLoggedIn = useSelector((state: RootState) => state.user.isLoggedIn);
   const { data: likeStatus, refetch } = useCheckLikeStatusQuery(postId);
   const [toggleLike] = useToggleLikeMutation();
+
+  useEffect(() => {
+    if (!isLoggedIn) {
+      refetch();
+    }
+    // eslint-disable-next-line
+  }, [isLoggedIn]);
 
   const handleLike = async () => {
     if (!isLoggedIn) return;

--- a/src/components/FeedPage/PostCard/PostCardFooter.tsx
+++ b/src/components/FeedPage/PostCard/PostCardFooter.tsx
@@ -31,8 +31,7 @@ const PostCardFooter = ({ postId, isbn }: PostCardFooterProps): JSX.Element => {
     if (!isLoggedIn) {
       refetch();
     }
-    // eslint-disable-next-line
-  }, [isLoggedIn]);
+  }, [isLoggedIn, refetch]);
 
   const handleLike = async () => {
     if (!isLoggedIn) {

--- a/src/components/FeedPage/PostCard/PostCardFooter.tsx
+++ b/src/components/FeedPage/PostCard/PostCardFooter.tsx
@@ -9,9 +9,10 @@ import {
   useCheckLikeStatusQuery,
   useToggleLikeMutation,
 } from '@features/commons/likeApi';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { RootState } from '@store/index';
 import { useEffect } from 'react';
+import { showSnackbar } from '@features/Snackbar/snackbarSlice';
 
 interface PostCardFooterProps {
   postId: string;
@@ -20,6 +21,7 @@ interface PostCardFooterProps {
 
 const PostCardFooter = ({ postId, isbn }: PostCardFooterProps): JSX.Element => {
   const navigate = useNavigate();
+  const dispatch = useDispatch();
   const theme = useTheme();
   const isLoggedIn = useSelector((state: RootState) => state.user.isLoggedIn);
   const { data: likeStatus, refetch } = useCheckLikeStatusQuery(postId);
@@ -33,7 +35,17 @@ const PostCardFooter = ({ postId, isbn }: PostCardFooterProps): JSX.Element => {
   }, [isLoggedIn]);
 
   const handleLike = async () => {
-    if (!isLoggedIn) return;
+    if (!isLoggedIn) {
+      // 로그인 상태가 아닐 때 스낵바 메시지와 리다이렉트 처리
+      dispatch(
+        showSnackbar({
+          message: '로그인 후 이용해주세요.',
+          severity: 'warning',
+        }),
+      );
+      navigate('/login'); // 로그인 페이지로 이동
+      return;
+    }
     try {
       await toggleLike(postId);
       refetch();


### PR DESCRIPTION
## 연관 이슈

- #251 

## 작업 요약

- 피드페이지에서 로그아웃 시 좋아요 상태 리페치
- 비로그인 상태에서 좋아요 처리

## 작업 상세 설명

- 로그아웃 시 좋아요 상태 조회 쿼리 강제 리페치
- 비로그인 상태에서 좋아요 버튼 누를 시, 스낵바 표시 후 로그인 페이지로 이동

## 리뷰 요구사항
- 리뷰 예상 시간: 3분
- 버튼 비활성화 처리도 해보았지만 좋아요 수가 눈에 띄지 않고 로그인 & 회원가입 유도하는 게 나을 것 같아서 로그인 페이지로 이동하도록 했습니다.

## 버튼 비활성화 이미지
![image](https://github.com/user-attachments/assets/968f85bc-f618-4a0a-8c26-ebf7675585b3) 