### PR TITLE
책 상세페이지 리뷰 탭 오류 수정

### DIFF
--- a/src/components/BookDetailPage/BookFeedTab.tsx
+++ b/src/components/BookDetailPage/BookFeedTab.tsx
@@ -37,6 +37,9 @@ const BookFeedTab = ({
   const { data: latestReviews } = useGetLatestBookReviewsQuery({ isbn });
   const { data: bookPostCount } = useGetBookPostCountQuery({ isbn });
 
+  console.log('latestReviews:', latestReviews);
+  console.log('bookPostCount', bookPostCount);
+  console.log('latestPostings', latestPostings);
   const handleModalClose = () => {
     setIsOneLineReviewModalOpen(false);
   };
@@ -64,7 +67,7 @@ const BookFeedTab = ({
         />
         <Box sx={bookReviewTabStyles.sectionHeader}>
           <Typography variant="h6" fontWeight="bold">
-            한줄평 ({bookPostCount?.review_count})
+            한줄평 ({bookPostCount?.review_count || 0})
           </Typography>
           <Button
             size="small"
@@ -75,7 +78,7 @@ const BookFeedTab = ({
             더보기
           </Button>
         </Box>
-        {latestReviews ? (
+        {Array.isArray(latestReviews) && latestReviews.length > 0 ? (
           <Grid container spacing={2}>
             {latestReviews.map((review, index) => (
               <Grid
@@ -115,7 +118,7 @@ const BookFeedTab = ({
       <Box>
         <Box sx={bookReviewTabStyles.sectionHeader}>
           <Typography variant="h6" fontWeight="bold">
-            포스팅 ({bookPostCount?.posting_count})
+            포스팅 ({bookPostCount?.posting_count || 0})
           </Typography>
           <Button
             size="small"
@@ -126,7 +129,7 @@ const BookFeedTab = ({
             더보기
           </Button>
         </Box>
-        {latestPostings ? (
+        {Array.isArray(latestPostings) && latestPostings.length > 0 ? (
           <Grid container spacing={2}>
             {latestPostings.map((posting, index) => (
               <Grid

--- a/src/components/BookDetailPage/BookFeedTab.tsx
+++ b/src/components/BookDetailPage/BookFeedTab.tsx
@@ -37,9 +37,6 @@ const BookFeedTab = ({
   const { data: latestReviews } = useGetLatestBookReviewsQuery({ isbn });
   const { data: bookPostCount } = useGetBookPostCountQuery({ isbn });
 
-  console.log('latestReviews:', latestReviews);
-  console.log('bookPostCount', bookPostCount);
-  console.log('latestPostings', latestPostings);
   const handleModalClose = () => {
     setIsOneLineReviewModalOpen(false);
   };

--- a/src/components/BookDetailPage/BookMyReview.tsx
+++ b/src/components/BookDetailPage/BookMyReview.tsx
@@ -22,9 +22,10 @@ const BookMyReview = ({
   onRatingChange,
   openDialog,
 }: BookMyReviewProps): JSX.Element => {
-  const { id: currentUserId } = useSelector(
+  const userInfo = useSelector(
     (state: RootState) => state.user.userInfo as UserInfo,
   );
+  const currentUserId = userInfo?.id ?? null; // userInfo가 없으면 null 처리
 
   const {
     data: userReview,

--- a/src/features/BookDetailPage/api/bookOwnReviewApi.ts
+++ b/src/features/BookDetailPage/api/bookOwnReviewApi.ts
@@ -36,11 +36,9 @@ export const bookOwnReviewApi = createApi({
 
           const transformedReview: UserReview = {
             postId: data.id,
-            review: data.one_line_review.review,
-            rating: data.one_line_review.rating,
-            book: {
-              isbn: data.isbn,
-            },
+            review: data.one_line_review?.review ?? '',
+            rating: data.one_line_review?.rating ?? 0,
+            book: { isbn: data.isbn },
             createdAt: data.created_at,
             user: {
               id: data.user.id,


### PR DESCRIPTION
## 연관 이슈

- #248 

## 작업 요약

- 로그인 하지 않은 상태에서 책 상세페이지에 리뷰탭이 오류나는 현상 수정
- 한줄평, 포스팅 수는 현재 undefined를 반환해서 ( 만약 리뷰, 한줄평이 없을때 ) 값이 없다면 0을 반환하도록 함
-  리뷰가 없습니다, 포스팅이 없습니다가 보이지 않는 부분은 
  - 조건문을 수정하여 배열이고, 요소가 있을 때만 포스트, 한줄평을 렌더링 하도록 수정


## 리뷰 요구사항
- @deenuit113  api 오류 처리가 따로 필요할 것 같습니다!

## Preview 이미지 (필요시)
![스크린샷 2025-02-19 오후 1 27 02](https://github.com/user-attachments/assets/029078d2-daec-4442-9e55-bd273f70076c)
![스크린샷 2025-02-19 오후 1 26 56](https://github.com/user-attachments/assets/ea65650b-0987-4452-a884-570be3af98dd)


