### PR TITLE
프로필 사진 업로드 시 이미지 압축

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@mui/x-date-pickers": "^7.26.0",
         "@reduxjs/toolkit": "^2.5.0",
         "@supabase/supabase-js": "^2.47.13",
+        "browser-image-compression": "^2.0.2",
         "dayjs": "^1.11.13",
         "html-react-parser": "^5.2.1",
         "lodash": "^4.17.21",
@@ -5959,6 +5960,15 @@
       "resolved": "https://registry.npmjs.org/browser-assert/-/browser-assert-1.2.1.tgz",
       "integrity": "sha512-nfulgvOR6S4gt9UKCeGJOuSGBPGiFT6oQ/2UBnvTY/5aQ1PnksW72fhZkM30DzoRRv2WpwZf1vHHEr3mtuXIWQ==",
       "dev": true
+    },
+    "node_modules/browser-image-compression": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/browser-image-compression/-/browser-image-compression-2.0.2.tgz",
+      "integrity": "sha512-pBLlQyUf6yB8SmmngrcOw3EoS4RpQ1BcylI3T9Yqn7+4nrQTXJD4sJDe5ODnJdrvNMaio5OicFo75rDyJD2Ucw==",
+      "license": "MIT",
+      "dependencies": {
+        "uzip": "0.20201231.0"
+      }
     },
     "node_modules/browserslist": {
       "version": "4.24.4",
@@ -13512,6 +13522,12 @@
       "bin": {
         "uuid": "dist/bin/uuid"
       }
+    },
+    "node_modules/uzip": {
+      "version": "0.20201231.0",
+      "resolved": "https://registry.npmjs.org/uzip/-/uzip-0.20201231.0.tgz",
+      "integrity": "sha512-OZeJfZP+R0z9D6TmBgLq2LHzSSptGMGDGigGiEe0pr8UBe/7fdflgHlHBNDASTXB5jnFuxHpNaJywSg8YFeGng==",
+      "license": "MIT"
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@mui/x-date-pickers": "^7.26.0",
     "@reduxjs/toolkit": "^2.5.0",
     "@supabase/supabase-js": "^2.47.13",
+    "browser-image-compression": "^2.0.2",
     "dayjs": "^1.11.13",
     "html-react-parser": "^5.2.1",
     "lodash": "^4.17.21",

--- a/src/features/user/userApi.ts
+++ b/src/features/user/userApi.ts
@@ -1,6 +1,7 @@
 import { createApi, fakeBaseQuery } from '@reduxjs/toolkit/query/react';
 import deleteUserFiles from '@utils/deleteUserFiles';
 import { supabase } from '@utils/supabaseClient';
+import imageCompression from 'browser-image-compression';
 
 export const userApi = createApi({
   reducerPath: 'userApi',
@@ -55,10 +56,18 @@ export const userApi = createApi({
     updateAvatar: builder.mutation({
       async queryFn({ userId, file }) {
         try {
-          const filePath = `${userId}/${Date.now()}_${file.name}`;
+          const options = {
+            maxSizeMB: 1,
+            maxWidthOrHeight: 500,
+            useWebWorker: true,
+          };
+
+          const compressedFile = await imageCompression(file, options);
+
+          const filePath = `${userId}/${Date.now()}_${compressedFile.name}`;
           const { error } = await supabase.storage
             .from('avatars')
-            .upload(filePath, file);
+            .upload(filePath, compressedFile);
 
           if (error) {
             return { error };


### PR DESCRIPTION
## 연관 이슈
- #267 

## 작업 요약
- 프로필 사진 업로드 시 이미지 압축

## 작업 상세 설명
- 이미지 최대 너비 & 높이 최대 500px로 고정
- 이미지 최대 용량 1MB > 네트워크 대역폭 절약
- web worker 사용 (메인 스레드와 분리하여 백그라운드에서 이미지 압축 > UI랑 별개로 작동)

### 추가되는 Dependency
- browser-image-compression

## 리뷰 요구사항
- 리뷰 예상시간: 1분

## 이미지
- 이미지 크기 1MB이하로 줄임
- supabase storage 캡처
![image](https://github.com/user-attachments/assets/ec2f549a-bed5-4713-83d5-6791187c5649)
![image](https://github.com/user-attachments/assets/790e8e56-5b15-43f2-8910-08faa3226d9c)

